### PR TITLE
fix: fix for newlines in filename

### DIFF
--- a/src/IconicPlugin.ts
+++ b/src/IconicPlugin.ts
@@ -811,7 +811,7 @@ export default class IconicPlugin extends Plugin {
 		const subpath = subpathStart > -1 ? fileId.substring(subpathStart, fileId.length) : '';
 		const path = subpathStart > -1 ? fileId.substring(0, subpathStart) : fileId;
 
-		const [, tree = '', filename] = path.match(/^(.*\/)?(.*)$/) ?? [];
+		const [, tree = '', filename] = path.match(/^(.*\/)?(.*)$/s) ?? [];
 		const extensionStart = filename.lastIndexOf('.');
 		const extension = filename.substring(extensionStart > -1 ? extensionStart + 1 : filename.length) || '';
 		const basename = filename.substring(0, extensionStart > -1 ? extensionStart : filename.length) || '';


### PR DESCRIPTION
FIXES: gfxholo/iconic#49

How to test:

- Install beta version with BRAT as a frozen version (`johannrichard/iconic` / `1.1.2-beta.1`) 📦 
- Create a file with a linebreak (see below how to do this) and add some content
- Enable Iconic ✔️  (and optionally add an icon for the file with a line break)
- Error is gone ✨ 

```bash
$ cd YOUR/OBSIDIAN/VAULT
$ touch "Filename with 
a line break.md"
```


