### PR TITLE
Add metadata change callbacks

### DIFF
--- a/src/IconicPlugin.ts
+++ b/src/IconicPlugin.ts
@@ -333,15 +333,10 @@ export default class IconicPlugin extends Plugin {
 				}
 			}));
 
-			this.registerEvent(this.app.vault.on('modify', tAbstractFile => {
-				const page = tAbstractFile instanceof TFile ? 'file' : 'folder';
-				// If a modified file/folder triggers a new ruling, refresh icons
-				if (this.ruleManager.triggerRulings(page, 'modify')) {
-					if (page === 'file') this.tabIconManager?.refreshIcons();
-					this.fileIconManager?.refreshIcons();
-					this.bookmarkIconManager?.refreshIcons();
-				}
-			}));
+			this.registerEvent(this.app.vault.on('modify', af => this.onModify(af)));
+			// @ts-expect-error Dataview types not always present
+			this.registerEvent(this.app.metadataCache.on('dataview:metadata-change', (_, af) => this.onModify(af)));
+			this.registerEvent(this.app.metadataCache.on('changed', af => this.onModify(af)));
 
 			this.registerEvent(this.app.vault.on('delete', (tAbstractFile) => {
 				const { path } = tAbstractFile;
@@ -1329,6 +1324,16 @@ export default class IconicPlugin extends Plugin {
 				if (fileIcon.unsynced?.includes(appId)) fileIcon.unsynced?.remove(appId);
 				if (fileIcon.unsynced?.length === 0) delete fileIcon.unsynced;
 			}
+		}
+	}
+
+	private onModify(abstractFile: TAbstractFile) {
+		const page = abstractFile instanceof TFile ? 'file' : 'folder';
+		// If a modified file/folder triggers a new ruling, refresh icons
+		if (this.ruleManager.triggerRulings(page, 'modify')) {
+			if (page === 'file') this.tabIconManager?.refreshIcons();
+			this.fileIconManager?.refreshIcons();
+			this.bookmarkIconManager?.refreshIcons();
 		}
 	}
 


### PR DESCRIPTION
Currently, I have a problem that when I edit metadata properties (in frontmatter, if that matters), then I don't get the right update to the icons. Its one change behind, probably a race condition of some kind or other.

This is a fix for that. It adds callbacks to both the vanilla meta store change event & the dataview one. I don't know if the dataview one is necessary, but another one doesn't hurt. I tested with and without dataview enabled & it worked both times so why not?

Also, I noticed that there are only very broad refresh functions, but is there a way to target only the modified files? That might help with performance