### PR TITLE
Fix empty (null) tags

### DIFF
--- a/src/managers/RuleManager.ts
+++ b/src/managers/RuleManager.ts
@@ -522,7 +522,7 @@ export default class RuleManager {
 					const propTags = metadata?.frontmatter?.tags ?? [];
 					const inlineTags = metadata?.tags?.map(tag => tag.tag.replace('#', '')) ?? [];
 					for (const tag of [...propTags, ...inlineTags]) {
-						if (!source.includes(tag)) source.push(tag);
+						if (!source.includes(tag) && tag) source.push(tag);
 					}
 					break;
 				}


### PR DESCRIPTION
In my vault, I have a couple of tags which are null (through front matter shenanigans):

```yaml
tags:
  - 
```

This plugin crashes when I have a tag condition and a null tag. This PR should fix that (tested and my case no longer crashes it)