### PR TITLE
refactor: extend typings with TS declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
+		"electron": "^36.2.1",
 		"esbuild": "0.17.3",
 		"obsidian": "latest",
 		"tslib": "2.4.0",

--- a/src/IconicPlugin.ts
+++ b/src/IconicPlugin.ts
@@ -1,4 +1,4 @@
-import { Command, Platform, Plugin, TAbstractFile, TFile, TFolder, View, WorkspaceLeaf, getIconIds } from 'obsidian';
+import { Command, Platform, Plugin, PropertyInfo, TAbstractFile, TFile, TFolder, View, WorkspaceLeaf, WorkspaceMobileDrawer, WorkspaceTabs, getIconIds } from 'obsidian';
 import IconicSettingTab from 'src/IconicSettingTab';
 import EMOJIS from 'src/Emojis';
 import STRINGS from 'src/Strings';
@@ -551,8 +551,7 @@ export default class IconicPlugin extends Plugin {
 		body.toggleClass('iconic-uncolor-drag', unloading ? false : this.settings.uncolorDrag);
 		body.toggleClass('iconic-uncolor-select', unloading ? false : this.settings.uncolorSelect);
 
-		// @ts-expect-error (Private API)
-		const theme = this.app.customCss?.theme;
+		const theme = this.app.customCss.theme;
 		body.toggleClass('iconic-theme-btopaz', unloading ? false : theme === 'Blue Topaz');
 		body.toggleClass('iconic-theme-border', unloading ? false : theme === 'Border');
 		body.toggleClass('iconic-theme-cat', unloading ? false : theme === 'Catppuccin');
@@ -583,8 +582,7 @@ export default class IconicPlugin extends Plugin {
 	 * Check whether a community plugin is installed and enabled.
 	 */
 	isPluginEnabled(pluginId: string): boolean {
-		// @ts-expect-error (Private API)
-		return this.app.plugins?.plugins?.hasOwnProperty(pluginId) === true;
+		return this.app.plugins.plugins.hasOwnProperty(pluginId) === true;
 	}
 
 	/**
@@ -664,26 +662,25 @@ export default class IconicPlugin extends Plugin {
 	 * Create tab definition.
 	 */
 	private defineTabItem(leaf: WorkspaceLeaf, unloading?: boolean): TabItem {
-		// @ts-expect-error (Private API)
 		let iconEl: HTMLElement | null = leaf.tabHeaderInnerIconEl;
 		if (Platform.isMobile) {
-			// @ts-expect-error (Private API)
-			if (leaf.containerEl?.parentElement === this.app.workspace.leftSplit.activeTabContentEl) {
-				// @ts-expect-error (Private API)
+			if (
+				this.app.workspace.leftSplit instanceof WorkspaceMobileDrawer &&
+				leaf.containerEl?.parentElement === this.app.workspace.leftSplit.activeTabContentEl
+			) {
 				iconEl = this.app.workspace.leftSplit.activeTabIconEl;
-				// @ts-expect-error (Private API)
-			} else if (leaf.containerEl?.parentElement === this.app.workspace.rightSplit.activeTabContentEl) {
-				// @ts-expect-error (Private API)
+			} else if (
+				this.app.workspace.rightSplit instanceof WorkspaceMobileDrawer &&
+				leaf.containerEl?.parentElement === this.app.workspace.rightSplit.activeTabContentEl
+			) {
 				iconEl = this.app.workspace.rightSplit.activeTabIconEl;
 			}
 		}
 
 		const tabType = leaf.view.getViewType();
-		// @ts-expect-error (Private API)
-		const isActive = leaf.view === this.app.workspace.getActiveViewOfType(View) || leaf.tabHeaderEl?.hasClass('is-active');
+		const isActive = leaf.view === this.app.workspace.getActiveViewOfType(View) || leaf.tabHeaderEl.hasClass('is-active');
 		const isRoot = leaf.getRoot() === this.app.workspace.rootSplit;
-		// @ts-expect-error (Private API)
-		const isStacked = leaf.parent?.isStacked === true;
+		const isStacked = leaf.parent instanceof WorkspaceTabs ? leaf.parent.isStacked : false;
 
 		if (OPENABLE_TYPES.includes(tabType)) {
 			const filePath = leaf.view.getState().file; // Used because view.file is undefined on deferred views
@@ -704,7 +701,6 @@ export default class IconicPlugin extends Plugin {
 				isRoot: isRoot,
 				isStacked: isStacked,
 				iconEl: iconEl ?? null,
-				// @ts-expect-error (Private API)
 				tabEl: leaf.tabHeaderEl ?? null,
 			}
 		} else {
@@ -730,7 +726,6 @@ export default class IconicPlugin extends Plugin {
 				isRoot: isRoot,
 				isStacked: isStacked,
 				iconEl: iconEl ?? null,
-				// @ts-expect-error (Private API)
 				tabEl: leaf.tabHeaderEl ?? null,
 			}
 		}
@@ -823,8 +818,7 @@ export default class IconicPlugin extends Plugin {
 	 * Get array of bookmark definitions.
 	 */
 	getBookmarkItems(unloading?: boolean): BookmarkItem[] {
-		// @ts-expect-error (Private API)
-		const bmarkBases: any[] = this.app.internalPlugins?.plugins?.bookmarks?.instance?.items ?? [];
+		const bmarkBases = this.app.internalPlugins.getEnabledPluginById('bookmarks')?.items ?? [];
 		return bmarkBases.map(bmarkBase => this.defineBookmarkItem(bmarkBase, unloading));
 	}
 
@@ -832,8 +826,7 @@ export default class IconicPlugin extends Plugin {
 	 * Get bookmark definition.
 	 */
 	getBookmarkItem(bmarkId: string, isFileOrFolder: boolean, unloading?: boolean): BookmarkItem {
-		// @ts-expect-error (Private API)
-		const bmarkBases = this.flattenBookmarks(this.app.internalPlugins?.plugins?.bookmarks?.instance?.items ?? []);
+		const bmarkBases = this.flattenBookmarks(this.app.internalPlugins?.getEnabledPluginById('bookmarks')?.items ?? []);
 		const bmarkBase = bmarkBases.find(bmarkBase => {
 			return isFileOrFolder && bmarkBase.path + (bmarkBase.subpath ?? '') === bmarkId || bmarkBase.ctime === bmarkId
 		}) ?? {};
@@ -939,7 +932,6 @@ export default class IconicPlugin extends Plugin {
 	 * Get array of tag definitions.
 	 */
 	getTagItems(unloading?: boolean): TagItem[] {
-		// @ts-expect-error (Private API)
 		const tagHashes: string[] = Object.keys(this.app.metadataCache.getTags()) ?? [];
 		const tagBases = tagHashes.map(tagHash => {
 			return {
@@ -955,7 +947,6 @@ export default class IconicPlugin extends Plugin {
 	 */
 	getTagItem(tagId: string, unloading?: boolean): TagItem | null {
 		const tagHash = '#' + tagId;
-		// @ts-expect-error (Private API)
 		const tagHashes: string[] = Object.keys(this.app.metadataCache.getTags()) ?? [];
 		return tagHashes.includes(tagHash)
 			? this.defineTagItem({
@@ -984,8 +975,7 @@ export default class IconicPlugin extends Plugin {
 	 * Get array of property definitions.
 	 */
 	getPropertyItems(unloading?: boolean): PropertyItem[] {
-		// @ts-expect-error (Private API)
-		const propBases: any[] = Object.values(this.app.metadataTypeManager?.properties) ?? [];
+		const propBases = Object.values(this.app.metadataTypeManager.properties);
 		return propBases.map(propBase => this.definePropertyItem(propBase, unloading));
 	}
 
@@ -993,16 +983,19 @@ export default class IconicPlugin extends Plugin {
 	 * Get property definition.
 	 */
 	getPropertyItem(propId: string, unloading?: boolean): PropertyItem {
-		// @ts-expect-error (Private API)
-		const propBases: any[] = Object.values(this.app.metadataTypeManager?.properties) ?? [];
-		const propBase = propBases.find(propBase => propBase.name === propId) ?? {};
+		const propBases = Object.values(this.app.metadataTypeManager.properties);
+		const propBase = propBases.find(propBase => propBase.name === propId) ?? {
+			name: propId,
+			type: 'string',
+			count: 0
+		};
+
 		return this.definePropertyItem(propBase, unloading);
 	}
-
 	/**
 	 * Create property definition.
 	 */
-	private definePropertyItem(propBase: any, unloading?: boolean): PropertyItem {
+	private definePropertyItem(propBase: PropertyInfo, unloading?: boolean): PropertyItem {
 		const propIcon = this.settings.propertyIcons[propBase.name] ?? {};
 		let iconDefault;
 		switch (propBase.type) {
@@ -1031,7 +1024,6 @@ export default class IconicPlugin extends Plugin {
 	 * Get array of ribbon command definitions.
 	 */
 	getRibbonItems(unloading?: boolean): RibbonItem[] {
-		// @ts-expect-error (Private API)
 		const itemBases: any[] = this.app.workspace.leftRibbon.items ?? [];
 		return itemBases.map(item => this.defineRibbonItem(item, unloading));
 	}
@@ -1040,7 +1032,6 @@ export default class IconicPlugin extends Plugin {
 	 * Get ribbon command definition.
 	 */
 	getRibbonItem(itemId: string, unloading?: boolean): RibbonItem {
-		// @ts-expect-error (Private API)
 		const itemBase: any = this.app.workspace.leftRibbon.items
 			?.find((itemBase: any) => itemBase?.id === itemId) ?? {};
 		return this.defineRibbonItem(itemBase, unloading);
@@ -1245,22 +1236,17 @@ export default class IconicPlugin extends Plugin {
 	private pruneSettings(): void {
 		this.updateUnsyncedFiles();
 
-		// @ts-expect-error (Private API)
-		const isSyncing = this.app.internalPlugins?.plugins?.sync?.instance?.syncing === true;
-		// @ts-expect-error (Private API)
-		const isPaused = this.app.internalPlugins?.plugins?.sync?.instance?.pause === true;
+		const isSyncing = this.app.internalPlugins.getEnabledPluginById('sync')?.syncing === true;
+		const isPaused = this.app.internalPlugins.getEnabledPluginById('sync')?.pause === true;
 
 		// Disable pruning under these conditions
 		if (isSyncing || isPaused || this.settings.rememberDeletedItems) {
 			return;
 		}
 
-		// @ts-expect-error (Private API)
 		const thisAppId = this.app.appId;
-		// @ts-expect-error (Private API)
-		const bmarkBases = this.flattenBookmarks(this.app.internalPlugins?.plugins?.bookmarks?.instance?.items ?? []);
-		// @ts-expect-error (Private API)
-		const propBases = this.app.metadataTypeManager?.properties ?? [];
+		const bmarkBases = this.flattenBookmarks(this.app.internalPlugins.getEnabledPluginById('bookmarks')?.items ?? []);
+		const propIds = Object.keys(this.app.metadataTypeManager.properties) ?? [];
 
 		const fileIcons = Object.entries(this.settings.fileIcons).filter(([fileId, fileIcon]) =>
 			// Never prune files that are unsynced on another device
@@ -1288,8 +1274,7 @@ export default class IconicPlugin extends Plugin {
 			}
 		}
 
-		if (propBases.length > 0) {
-			const propIds = Object.keys(propBases);
+		if (propIds.length > 0) {
 			for (const propId in this.settings.propertyIcons) {
 				if (!propIds.includes(propId)) {
 					delete this.settings.propertyIcons[propId];
@@ -1302,12 +1287,9 @@ export default class IconicPlugin extends Plugin {
 	 * Flag any files excluded from Sync on this device.
 	 */
 	private updateUnsyncedFiles(): void {
-		// @ts-expect-error (Private API)
 		const appId = this.app.appId;
-		// @ts-expect-error (Private API)
-		const unsyncedFolders: string[] = this.app.internalPlugins?.plugins?.sync?.instance?.ignoreFolders ?? [];
-		// @ts-expect-error (Private API)
-		const unsyncedTypes: string[] = SYNCABLE_TYPES.filter(type => !this.app.internalPlugins?.plugins?.sync?.instance?.allowTypes.has(type));
+		const unsyncedFolders: string[] = this.app.internalPlugins.getEnabledPluginById('sync')?.ignoreFolders ?? [];
+		const unsyncedTypes: string[] = SYNCABLE_TYPES.filter(type => !this.app.internalPlugins.getEnabledPluginById('sync')?.allowTypes.has(type));
 
 		for (const [fileId, fileIcon] of Object.entries(this.settings.fileIcons)) {
 			if (!Array.isArray(fileIcon.unsynced)) {

--- a/src/IconicSettingTab.ts
+++ b/src/IconicSettingTab.ts
@@ -36,7 +36,6 @@ export default class IconicSettingTab extends PluginSettingTab {
 				.onClick(() => {
 					// Silently no-op if rulebook hasn't finished loading
 					if (!this.plugin.ruleManager) return;
-					// @ts-expect-error (Private API)
 					this.app.setting.close();
 					RulePicker.open(this.plugin);
 				});

--- a/src/dialogs/IconPicker.ts
+++ b/src/dialogs/IconPicker.ts
@@ -119,8 +119,7 @@ export default class IconPicker extends Modal {
 
 		// Allow hotkeys in icon picker
 		for (const command of this.plugin.commands) if (command.callback) {
-			// @ts-expect-error (Private API)
-			const hotkeys: Hotkey[] = this.app.hotkeyManager?.customKeys?.[command.id] ?? [];
+			const hotkeys: Hotkey[] = this.app.hotkeyManager.customKeys[command.id] ?? [];
 			for (const hotkey of hotkeys) {
 				this.scope.register(hotkey.modifiers, hotkey.key, command.callback);
 			}
@@ -494,7 +493,6 @@ export default class IconPicker extends Modal {
 					this.updateColorPicker();
 					this.updateSearchResults();
 				});
-				// @ts-expect-error (Private API)
 				this.iconManager.refreshIcon({ icon: 'lucide-paint-bucket', color }, menuItem.iconEl);
 			});
 		}

--- a/src/dialogs/RuleChecker.ts
+++ b/src/dialogs/RuleChecker.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, Modal, Setting } from 'obsidian';
+import { ButtonComponent, Hotkey, Modal, Setting } from 'obsidian';
 import IconicPlugin, { FileItem, STRINGS } from 'src/IconicPlugin';
 import { RulePage } from 'src/managers/RuleManager';
 
@@ -18,8 +18,7 @@ export default class RuleChecker extends Modal {
 
 		// Allow hotkeys in rule checker
 		for (const command of this.plugin.commands) if (command.callback) {
-			// @ts-expect-error (Private API)
-			const hotkeys: Hotkey[] = this.app.hotkeyManager?.customKeys?.[command.id] ?? [];
+			const hotkeys: Hotkey[] = this.app.hotkeyManager.customKeys[command.id] ?? [];
 			for (const hotkey of hotkeys) {
 				this.scope.register(hotkey.modifiers, hotkey.key, command.callback);
 			}

--- a/src/dialogs/RuleEditor.ts
+++ b/src/dialogs/RuleEditor.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, DropdownComponent, ExtraButtonComponent, Modal, Platform, Setting, TextComponent } from 'obsidian';
+import { ButtonComponent, DropdownComponent, ExtraButtonComponent, Hotkey, Modal, Platform, Setting, TextComponent } from 'obsidian';
 import IconicPlugin, { Icon, Item, FileItem, STRINGS } from 'src/IconicPlugin';
 import ColorUtils from 'src/ColorUtils';
 import { RulePage, RuleItem, ConditionItem } from 'src/managers/RuleManager';
@@ -527,8 +527,7 @@ export default class RuleEditor extends Modal {
 
 		// Allow hotkeys in rule editor
 		for (const command of this.plugin.commands) if (command.callback) {
-			// @ts-expect-error (Private API)
-			const hotkeys: Hotkey[] = this.app.hotkeyManager?.customKeys?.[command.id] ?? [];
+			const hotkeys: Hotkey[] = this.app.hotkeyManager.customKeys[command.id] ?? [];
 			for (const hotkey of hotkeys) {
 				this.scope.register(hotkey.modifiers, hotkey.key, command.callback);
 			}
@@ -759,7 +758,6 @@ export default class RuleEditor extends Modal {
 
 		// Show a loading spinner if check takes longer than 100ms
 		const timeoutId = setTimeout(() => {
-			// @ts-expect-error (Private API)
 			this.matchesButton.setLoading(true);
 			this.matchesButton.setDisabled(true);
 		}, 100);
@@ -782,7 +780,6 @@ export default class RuleEditor extends Modal {
 				break;
 			}
 		}
-		// @ts-expect-error (Private API)
 		this.matchesButton.setLoading(false);
 		this.matchesButton.setDisabled(this.matches.length === 0);
 	}

--- a/src/dialogs/RulePicker.ts
+++ b/src/dialogs/RulePicker.ts
@@ -1,4 +1,4 @@
-import { ExtraButtonComponent, Menu, Modal, Setting, ToggleComponent } from 'obsidian';
+import { ExtraButtonComponent, Hotkey, Menu, Modal, Setting, ToggleComponent } from 'obsidian';
 import IconicPlugin, { Icon, Item, STRINGS } from 'src/IconicPlugin';
 import ColorUtils from 'src/ColorUtils';
 import { RulePage, RuleItem } from 'src/managers/RuleManager';
@@ -70,8 +70,7 @@ export default class RulePicker extends Modal {
 
 		// Allow hotkeys in rule picker
 		for (const command of this.plugin.commands) if (command.callback) {
-			// @ts-expect-error (Private API)
-			const hotkeys: Hotkey[] = this.app.hotkeyManager?.customKeys?.[command.id] ?? [];
+			const hotkeys: Hotkey[] = this.app.hotkeyManager.customKeys[command.id] ?? [];
 			for (const hotkey of hotkeys) {
 				this.scope.register(hotkey.modifiers, hotkey.key, command.callback);
 			}

--- a/src/managers/AppIconManager.ts
+++ b/src/managers/AppIconManager.ts
@@ -157,8 +157,9 @@ export default class AppIconManager extends IconManager {
 	 * Refresh maximize icon only. This button can have two states: maximized or unmaximized.
 	 */
 	private refreshMaximizeIcon(unloading?: boolean): void {
-		// @ts-expect-error (Electron API)
-		const isMaximized = activeWindow.electron.remote.getCurrentWindow().isMaximized() ?? true;
+		const isMaximized = Platform.isDesktop
+			? activeWindow.electronWindow.isMaximized()
+			: false;
 
 		if (this.maximizeEl) this.stopMutationObserver(this.maximizeEl);
 		if (!activeDocument.contains(this.maximizeEl)) {

--- a/src/managers/BookmarkIconManager.ts
+++ b/src/managers/BookmarkIconManager.ts
@@ -228,8 +228,8 @@ export default class BookmarkIconManager extends IconManager {
 		);
 
 		// Remove icon(s) / Reset color(s)
-		const anyRemovable = selectedBmarks.some(bmark => bmark.icon || bmark.color);
-		const anyIcons = selectedBmarks.some(bmark => bmark.icon);
+		const anyRemovable = selectedBmarks.some(bmark => !!(bmark.icon || bmark.color));
+		const anyIcons = selectedBmarks.some(bmark => !!bmark.icon);
 		const removeTitle = selectedBmarks.length < 2
 			? clickedBmark.icon
 				? STRINGS.menu.removeIcon

--- a/src/managers/EditorIconManager.ts
+++ b/src/managers/EditorIconManager.ts
@@ -76,8 +76,7 @@ export default class EditorIconManager extends IconManager {
 		this.observeContainer(view.containerEl, view);
 
 		// Properties list
-		// @ts-expect-error (Private API)
-		const propsEl: HTMLElement = view.metadataEditor?.propertyListEl;
+		const propsEl: HTMLElement = view.metadataEditor.propertyListEl;
 		if (!propsEl) return;
 		this.observeProperties(propsEl, view);
 
@@ -184,8 +183,7 @@ export default class EditorIconManager extends IconManager {
 	 * Refresh all property icons in a single MarkdownView.
 	 */
 	private refreshPropertyIcons(props: PropertyItem[], view: MarkdownView): void {
-		// @ts-expect-error (Private API)
-		const propListEl: HTMLElement = view.metadataEditor?.propertyListEl;
+		const propListEl: HTMLElement = view.metadataEditor.propertyListEl;
 		if (!propListEl) return;
 		const propEls = propListEl.findAll(':scope > .metadata-property');
 
@@ -203,8 +201,7 @@ export default class EditorIconManager extends IconManager {
 	 * Refresh all tag icons in a single MarkdownView.
 	*/
 	private refreshTagIcons(tags: TagItem[], view: MarkdownView): void {
-		// @ts-expect-error (Private API)
-		const propListEl: HTMLElement = view.metadataEditor?.propertyListEl;
+		const propListEl: HTMLElement = view.metadataEditor.propertyListEl;
 		if (!propListEl) return;
 		const propTagEls = view.contentEl.findAll('.metadata-property[data-property-key="tags"] .multi-select-pill');
 		if (!propTagEls) return;

--- a/src/managers/FileIconManager.ts
+++ b/src/managers/FileIconManager.ts
@@ -102,7 +102,7 @@ export default class FileIconManager extends IconManager {
 
 						// Refresh when folder is expanded
 						if (mutation.attributeName === 'class' && mutation.target instanceof HTMLElement) {
-							const wasCollapsed = mutation.oldValue?.includes('is-collapsed');
+							const wasCollapsed = mutation.oldValue?.includes('is-collapsed') ?? false;
 							const isCollapsed = mutation.target.hasClass('is-collapsed');
 							return wasCollapsed && !isCollapsed; // Only trigger on expand
 						}
@@ -220,8 +220,8 @@ export default class FileIconManager extends IconManager {
 		);
 
 		// Remove icon(s) / Reset color(s)
-		const anyIcons = files.some(file => file.icon);
-		const anyColors = files.some(file => file.color);
+		const anyIcons = files.some(file => !!file.icon);
+		const anyColors = files.some(file => !!file.color);
 		const removalTitle = files.length === 1
 			? files[0].icon
 				? STRINGS.menu.removeIcon

--- a/src/managers/MenuManager.ts
+++ b/src/managers/MenuManager.ts
@@ -10,7 +10,7 @@ export default class MenuManager {
 	constructor() {
 		const manager = this;
 		Menu.prototype.showAtPosition = new Proxy(Menu.prototype.showAtPosition, {
-			apply(showAtPosition, menu, args) {
+			apply(showAtPosition, menu: Menu, args) {
 				manager.menu = menu;
 				if (manager.queuedActions.length > 0) {
 					manager.runQueuedActions.call(manager); // Menu is unhappy with your customer service
@@ -50,9 +50,7 @@ export default class MenuManager {
 
 			this.menu.addItem(item => {
 				callback(item);
-				// @ts-expect-error (Private API)
 				const section: string = item.section;
-				// @ts-expect-error (Private API)
 				const sections: string[] = this.menu?.sections ?? [];
 
 				let index = 0;
@@ -88,8 +86,7 @@ export default class MenuManager {
 	 */
 	forSection(section: string, callback: (item: MenuItem, index: number) => void): this {
 		if (this.menu) {
-			// @ts-expect-error (Private API)
-			const items = (this.menu.items as MenuItem[]).filter(item => item.section === section);
+			const items = this.menu.items.filter(item => item.section === section);
 			for (let i = 0; i < items.length; i++) {
 				callback(items[i], i);
 			}

--- a/src/managers/PropertyIconManager.ts
+++ b/src/managers/PropertyIconManager.ts
@@ -130,8 +130,8 @@ export default class PropertyIconManager extends IconManager {
 		);
 
 		// Remove icon(s) / Reset color(s)
-		const anySelectedIcons = selectedProps.some(file => file.icon);
-		const anySelectedColors = selectedProps.some(file => file.color);
+		const anySelectedIcons = selectedProps.some(file => !!file.icon);
+		const anySelectedColors = selectedProps.some(file => !!file.color);
 		const removeTitle = selectedProps.length < 2
 			? clickedProp.icon
 				? STRINGS.menu.removeIcon

--- a/src/managers/RibbonIconManager.ts
+++ b/src/managers/RibbonIconManager.ts
@@ -12,14 +12,15 @@ export default class RibbonIconManager extends IconManager {
 		super(plugin);
 		this.refreshIcons();
 
-		// @ts-expect-error (Private API)
-		const containerEl: HTMLElement = this.app.workspace.leftRibbon.ribbonItemsEl;
+		const containerEl = this.app.workspace.leftRibbon.ribbonItemsEl;
 
-		// Prevent ribbon from eating auxclick events
-		this.setEventListener(containerEl, 'auxclick', event => {
-			event.stopPropagation();
-		}, { capture: true });
-		this.setMutationsObserver(containerEl, { childList: true }, () => this.refreshIcons());
+		if (containerEl) {
+			// Prevent ribbon from eating auxclick events
+			this.setEventListener(containerEl, 'auxclick', event => {
+				event.stopPropagation();
+			}, { capture: true });
+			this.setMutationsObserver(containerEl, { childList: true }, () => this.refreshIcons());
+		}
 
 		// Refresh ribbon context menu
 		const ribbonEl = activeDocument.body.find(Platform.isDesktop
@@ -30,10 +31,8 @@ export default class RibbonIconManager extends IconManager {
 			const ribbonItems = this.plugin.getRibbonItems();
 			this.plugin.menuManager.forSection('order', item => {
 				const ribbonItem = ribbonItems[0];
-				// @ts-expect-error (Private API)
 				if (ribbonItem && item.iconEl.childElementCount > 0) { // Ribbon Divider compatibility
 					item.setIcon(ribbonItem.icon);
-					// @ts-expect-error (Private API)
 					this.refreshIcon(ribbonItem, item.iconEl);
 					ribbonItems.shift();
 				}
@@ -59,11 +58,9 @@ export default class RibbonIconManager extends IconManager {
 	 */
 	refreshIcons(unloading?: boolean): void {
 		if (Platform.isPhone) {
-			// @ts-expect-error (Private API)
-			const ribbonButtonEl = this.app.mobileNavbar.ribbonMenuItemEl;
+			const ribbonButtonEl = this.app.mobileNavbar?.ribbonMenuItemEl;
 			if (!ribbonButtonEl) return;
 
-			// @ts-expect-error (Private API)
 			const quickItemId = this.app.vault.getConfig('mobileQuickRibbonItem');
 			const ribbonButtonListener = () => {
 				const ribbonItems = this.plugin.getRibbonItems().filter(item => !item.isHidden);
@@ -71,7 +68,6 @@ export default class RibbonIconManager extends IconManager {
 					const ribbonItem = ribbonItems[0];
 					if (ribbonItem) {
 						item.setIcon(ribbonItem.icon);
-						// @ts-expect-error (Private API)
 						this.refreshIcon(ribbonItem, item.iconEl);
 						ribbonItems.shift();
 					}
@@ -115,7 +111,6 @@ export default class RibbonIconManager extends IconManager {
 				this.refreshConfigIcons(containerEl);
 			});
 
-			// @ts-expect-error (Private API)
 			const quickItemId = this.app.vault.getConfig('mobileQuickRibbonItem');
 			if (quickItemId) {
 				const quickItem = this.plugin.getRibbonItem(quickItemId);

--- a/src/managers/RuleManager.ts
+++ b/src/managers/RuleManager.ts
@@ -302,7 +302,7 @@ export default class RuleManager {
 				break;
 			}
 			case 'folder': {
-				const folders = this.plugin.getFileItems().filter(folder => folder.items);
+				const folders = this.plugin.getFileItems().filter(folder => !!folder.items);
 				// Prune folder rulings (remove folders that no longer exist)
 				const folderIds = folders.map(folder => folder.id);
 				for (const [folderId] of this.folderRulings) {
@@ -461,7 +461,7 @@ export default class RuleManager {
 	 * @param ignoreEnabled Ignore whether the rule is enabled.
 	 */
 	judgeFolders(rule: RuleItem, now: Date, ignoreEnabled?: true): FileItem[] {
-		const folders = this.plugin.getFileItems().filter(file => file.items);
+		const folders = this.plugin.getFileItems().filter(file => !!file.items);
 		const matches: FileItem[] = [];
 		for (const folder of folders) {
 			if (this.judgeFile(folder, rule, now, ignoreEnabled)) {

--- a/src/managers/TabIconManager.ts
+++ b/src/managers/TabIconManager.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'obsidian';
+import { Platform, WorkspaceMobileDrawer } from 'obsidian';
 import IconicPlugin, { FileItem, TabItem, STRINGS } from 'src/IconicPlugin';
 import IconManager from './IconManager';
 import RuleEditor from 'src/dialogs/RuleEditor';
@@ -21,7 +21,6 @@ export default class TabIconManager extends IconManager {
 				const tab = tabs[i];
 				if (tab) {
 					tab.iconDefault = tab.iconDefault ?? 'lucide-file';
-					// @ts-expect-error (Private API)
 					this.refreshIcon(tab, item.iconEl);
 				}
 			});
@@ -107,19 +106,18 @@ export default class TabIconManager extends IconManager {
 
 			// Update mobile sidebars
 			if (Platform.isMobile) {
-				// @ts-expect-error (Private API)
-				this.setEventListener(this.app.workspace.leftSplit.activeTabSelectEl, 'change', () => this.refreshIcons());
-				// @ts-expect-error (Private API)
-				this.setEventListener(this.app.workspace.rightSplit.activeTabSelectEl, 'change', () => this.refreshIcons());
-
-				// @ts-expect-error (Private API)
-				if (this.app.workspace.leftSplit.activeTabIconEl === iconEl) {
-					// @ts-expect-error (Private API)
-					this.setEventListener(this.app.workspace.leftSplit.activeTabHeaderEl, 'contextmenu', () => this.onContextMenu(tab.id, tab.isFile));
-					// @ts-expect-error (Private API)
-				} else if (this.app.workspace.rightSplit.activeTabIconEl === iconEl) {
-					// @ts-expect-error (Private API)
-					this.setEventListener(this.app.workspace.rightSplit.activeTabHeaderEl, 'contextmenu', () => this.onContextMenu(tab.id, tab.isFile));
+				const { leftSplit, rightSplit } = this.app.workspace;
+				if (leftSplit instanceof WorkspaceMobileDrawer) {
+					this.setEventListener(leftSplit.activeTabSelectEl, 'change', () => this.refreshIcons());
+					if (leftSplit.activeTabIconEl === iconEl) {
+						this.setEventListener(leftSplit.activeTabHeaderEl, 'contextmenu', () => this.onContextMenu(tab.id, tab.isFile));
+					}
+				}
+				if (rightSplit instanceof WorkspaceMobileDrawer) {
+					this.setEventListener(rightSplit.activeTabSelectEl, 'change', () => this.refreshIcons());
+					if (rightSplit.activeTabIconEl === iconEl) {
+						this.setEventListener(rightSplit.activeTabHeaderEl, 'contextmenu', () => this.onContextMenu(tab.id, tab.isFile));
+					}
 				}
 			}
 		}

--- a/src/typings/Electron.d.ts
+++ b/src/typings/Electron.d.ts
@@ -1,0 +1,9 @@
+import { BaseWindow } from "electron";
+
+declare global {
+	var electronWindow: BaseWindow;
+
+	interface Window {
+		electronWindow: BaseWindow;
+	}
+}

--- a/src/typings/Obsidian.d.ts
+++ b/src/typings/Obsidian.d.ts
@@ -1,0 +1,177 @@
+import 'obsidian';
+
+// Some typings were taken from Obsidian Extended Typings by Fevol, MIT licensed.
+// See: https://github.com/Fevol/obsidian-typings
+
+declare module 'obsidian' {
+	interface App {
+		appId: string;
+		customCss: CustomCss;
+		hotkeyManager: HotkeyManager;
+		internalPlugins: InternalPluginManager;
+		metadataTypeManager: MetadataTypeManager;
+		mobileNavbar: MobileNavbar | null;
+		plugins: PluginManager;
+		setting: AppSetting;
+	}
+
+	interface AppSetting extends Modal {}
+
+	interface BookmarkItem<T extends BookmarkItemType = BookmarkItemType> {
+		type: T;
+		title?: string | undefined;
+		path?: string | undefined;
+		url?: string | undefined;
+	}
+
+	type BookmarkItemType =
+		| 'file'
+		| 'folder'
+		| 'group'
+		| 'graph'
+		| 'search'
+		| 'url';
+
+	interface BookmarkLookup<T extends BookmarkItemType = BookmarkItemType> {
+		[path: string]: BookmarkItem<T>;
+	}
+
+	type BookmarksPlugin = InternalPlugin<BookmarksPluginInstance>;
+
+	interface BookmarksPluginInstance extends InternalPluginInstance, Events {
+		bookmarkLookup: BookmarkLookup<'file' | 'folder'>;
+		items: BookmarkItem[];
+		getBookmarks(): BookmarkItem[];
+		removeItem(item: BookmarkItem): void;
+		urlBookmarkLookup: BookmarkLookup<'url'>;
+	}
+
+	interface ButtonComponent {
+		setDisabled(on: boolean): this;
+		setLoading(on: boolean): this;
+	}
+
+	interface CustomCss extends Component {
+		theme: string;
+	}
+
+	interface HotkeyManager {
+		get customKeys(): Record<string, Hotkey[]>;
+	}
+
+	interface InternalPlugin<T extends InternalPluginInstance> extends Component {
+		instance: T;
+	}
+
+	interface InternalPluginInstance {}
+	
+	interface InternalPluginInstanceMap {
+		'bookmarks': BookmarksPluginInstance;
+		'sync': SyncPluginInstance;
+	}
+
+	interface InternalPluginManager extends Events {
+		plugins: {
+			[ID in keyof InternalPluginInstanceMap]: InternalPlugin<InternalPluginInstanceMap[ID]>;
+		};
+		getPluginById<T extends IntenalPluginIDs>(id: T): InternalPlugin<InternalPluginInstanceMap[T]>;
+		getEnabledPluginById<T extends IntenalPluginIDs>(id: T): InternalPluginInstanceMap[T] | null;
+	}
+
+	type IntenalPluginIDs = keyof InternalPluginInstanceMap;
+
+	interface MarkdownView {
+		metadataEditor: MetadataEditor;
+	}
+
+	interface MetadataCache {
+		getTags(): Record<string, number>;
+	}
+
+	interface MetadataEditor extends Component {
+		propertyListEl: HTMLElement;
+	}
+
+	interface MetadataTypeManager extends Events {
+		properties: Record<string, PropertyInfo>;
+	}
+
+	interface Menu {
+		items: MenuItem[];
+		sections: string[];
+	}
+
+	interface MenuItem {
+		iconEl: HTMLElement;
+		section: string;
+	}
+
+	interface MobileNavbar {
+		ribbonMenuItemEl: HTMLElement;
+	}
+
+	interface PluginManager {
+		plugins: PluginMap;
+	}
+
+	interface PluginMap {
+		[id: string]: Plugin;
+	}
+
+	interface PropertyInfo {
+		count: number;
+		name: string;
+		type: string;
+	}
+
+	interface RibbonItem {
+		buttonEl: HTMLElement;
+		callback: () => unknown;
+		hidden: boolean;
+		icon: IconName;
+		id: string;
+		title: string;
+	}
+
+	type SyncPlugin = InternalPlugin<SyncPluginInstance>;
+
+	interface SyncPluginInstance extends InternalPluginInstance, Events {
+		allowTypes: Set<string>;
+		ignoreFolders: string[];
+		pause: boolean;
+		syncing: boolean;
+	}
+
+	interface Vault {
+		getConfig<T extends keyof VaultConfig>(key: T): VaultConfig[T];
+	}
+
+	interface VaultConfig {
+		mobileQuickRibbonItem?: string;
+	}
+	
+	interface WorkspaceItem {
+		containerEl: HTMLElement;
+	}
+
+	interface WorkspaceLeaf {
+		tabHeaderEl: HTMLElement;
+		tabHeaderInnerIconEl: HTMLElement;
+	}
+
+	interface WorkspaceMobileDrawer {
+		activeTabContentEl: HTMLElement;
+		activeTabHeaderEl: HTMLElement;
+		activeTabIconEl: HTMLElement;
+		activeTabSelectEl: HTMLSelectElement;
+	}
+
+	interface WorkspaceRibbon {
+		items: RibbonItem[];
+		ribbonItemsEl: HTMLElement | null;
+	}
+
+	interface WorkspaceTabs {
+		isStacked: boolean;
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
 	  "strictNullChecks": true,
+    "allowSyntheticDefaultImports": true,
     "lib": [
       "DOM",
       "DOM.Iterable",


### PR DESCRIPTION
- Remove all `@ts-expect-error` flags.
- Fix some codes that don't match the typings.

FYI, after going through the typings provided by [Obsidian Extended Typings][obsidian-typings], I double-checked all those typings directly from Obsidian dev console, ensuring that declarations I wrote match with the implementations.

[obsidian-typings]: https://github.com/Fevol/obsidian-typings