### PR TITLE
Remove hardcoded property type icon names

### DIFF
--- a/src/IconicPlugin.ts
+++ b/src/IconicPlugin.ts
@@ -1131,18 +1131,9 @@ export default class IconicPlugin extends Plugin {
 	 */
 	private definePropertyItem(propBase: any, unloading?: boolean): PropertyItem {
 		const propIcon = this.settings.propertyIcons[propBase.name] ?? {};
-		let iconDefault;
-		switch (propBase.widget ?? propBase.type) { // Pre-1.9.0 compatible
-			case 'text': iconDefault = 'lucide-text'; break;
-			case 'multitext': iconDefault = 'lucide-list'; break;
-			case 'number': iconDefault = 'lucide-binary'; break;
-			case 'checkbox': iconDefault = 'lucide-check-square'; break;
-			case 'date': iconDefault = 'lucide-calendar'; break;
-			case 'datetime': iconDefault = 'lucide-clock'; break;
-			case 'aliases': iconDefault = 'lucide-forward'; break;
-			case 'tags': iconDefault = 'lucide-tags'; break;
-			default: iconDefault = 'lucide-file-question'; break;
-		}
+		// Pre-1.9.0 compatible
+		// @ts-expect-error internal Obsidian API
+		const iconDefault = this.app.metadataTypeManager.getWidget(propBase.widget ?? propBase.type)?.icon ?? 'lucide-file-question';
 		return {
 			id: propBase.name,
 			name: propBase.name,

--- a/src/IconicPlugin.ts
+++ b/src/IconicPlugin.ts
@@ -1132,7 +1132,7 @@ export default class IconicPlugin extends Plugin {
 	private definePropertyItem(propBase: any, unloading?: boolean): PropertyItem {
 		const propIcon = this.settings.propertyIcons[propBase.name] ?? {};
 		// Pre-1.9.0 compatible
-		// @ts-expect-error internal Obsidian API
+		// @ts-expect-error (Private API)
 		const iconDefault = this.app.metadataTypeManager.getWidget(propBase.widget ?? propBase.type)?.icon ?? 'lucide-file-question';
 		return {
 			id: propBase.name,


### PR DESCRIPTION
Previously, you were determining the default icon for properties based on the icon names you had hardcoded for the current property types. This update changes it so you just use the icon as defined for that property type in the `MetadataTypeManager`.

Not only does this make it future proof for when Obsidian adds additional property types and/or changes the icons for one of them, but it also makes it compatible with plugins that add additional property types-- see [Better Properties #27](https://github.com/unxok/obsidian-better-properties/issues/27)

(also you have 75 `@ts-expect-error`'s... why not use [obsidian-typings](https://github.com/Fevol/obsidian-typings)?)