### PR TITLE
Property Fixes for Obsidian 1.10.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "iconic",
 	"name": "Iconic",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"minAppVersion": "1.6.0",
 	"description": "Customize your icons and their colors directly from the UI, including tabs, files & folders, bookmarks, tags, properties, and ribbon commands.",
 	"author": "Holo",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,33 @@
 {
 	"name": "iconic",
 	"version": "1.1.4",
-	"lockfileVersion": 1,
+	"lockfileVersion": 3,
 	"requires": true,
-	"dependencies": {
-		"@codemirror/language": {
+	"packages": {
+		"": {
+			"name": "iconic",
+			"version": "1.1.4",
+			"license": "MIT-0",
+			"devDependencies": {
+				"@codemirror/language": "^6.11.2",
+				"@codemirror/state": "^6.5.2",
+				"@codemirror/view": "^6.38.0",
+				"@types/node": "^16.18.98",
+				"@typescript-eslint/eslint-plugin": "5.29.0",
+				"@typescript-eslint/parser": "5.29.0",
+				"builtin-modules": "3.3.0",
+				"esbuild": "0.17.3",
+				"obsidian": "^1.8.7",
+				"tslib": "2.4.0",
+				"typescript": "4.7.4"
+			}
+		},
+		"node_modules/@codemirror/language": {
 			"version": "6.11.2",
 			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.2.tgz",
 			"integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
 				"@lezer/common": "^1.1.0",
@@ -18,279 +36,486 @@
 				"style-mod": "^4.0.0"
 			}
 		},
-		"@codemirror/state": {
+		"node_modules/@codemirror/state": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
 			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
 		},
-		"@codemirror/view": {
+		"node_modules/@codemirror/view": {
 			"version": "6.38.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.0.tgz",
 			"integrity": "sha512-yvSchUwHOdupXkd7xJ0ob36jdsSR/I+/C+VbY0ffBiL5NiSTEBDfB1ZGWbbIlDd5xgdUkody+lukAdOxYrOBeg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@codemirror/state": "^6.5.0",
 				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
 			}
 		},
-		"@esbuild/android-arm": {
+		"node_modules/@esbuild/android-arm": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
 			"integrity": "sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==",
+			"cpu": [
+				"arm"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/android-arm64": {
+		"node_modules/@esbuild/android-arm64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
 			"integrity": "sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/android-x64": {
+		"node_modules/@esbuild/android-x64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
 			"integrity": "sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/darwin-arm64": {
+		"node_modules/@esbuild/darwin-arm64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
 			"integrity": "sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/darwin-x64": {
+		"node_modules/@esbuild/darwin-x64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
 			"integrity": "sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/freebsd-arm64": {
+		"node_modules/@esbuild/freebsd-arm64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
 			"integrity": "sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/freebsd-x64": {
+		"node_modules/@esbuild/freebsd-x64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
 			"integrity": "sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/linux-arm": {
+		"node_modules/@esbuild/linux-arm": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
 			"integrity": "sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==",
+			"cpu": [
+				"arm"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/linux-arm64": {
+		"node_modules/@esbuild/linux-arm64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
 			"integrity": "sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/linux-ia32": {
+		"node_modules/@esbuild/linux-ia32": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
 			"integrity": "sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==",
+			"cpu": [
+				"ia32"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/linux-loong64": {
+		"node_modules/@esbuild/linux-loong64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
 			"integrity": "sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==",
+			"cpu": [
+				"loong64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/linux-mips64el": {
+		"node_modules/@esbuild/linux-mips64el": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
 			"integrity": "sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==",
+			"cpu": [
+				"mips64el"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/linux-ppc64": {
+		"node_modules/@esbuild/linux-ppc64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
 			"integrity": "sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==",
+			"cpu": [
+				"ppc64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/linux-riscv64": {
+		"node_modules/@esbuild/linux-riscv64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
 			"integrity": "sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==",
+			"cpu": [
+				"riscv64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/linux-s390x": {
+		"node_modules/@esbuild/linux-s390x": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
 			"integrity": "sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==",
+			"cpu": [
+				"s390x"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/linux-x64": {
+		"node_modules/@esbuild/linux-x64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
 			"integrity": "sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/netbsd-x64": {
+		"node_modules/@esbuild/netbsd-x64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
 			"integrity": "sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/openbsd-x64": {
+		"node_modules/@esbuild/openbsd-x64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
 			"integrity": "sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/sunos-x64": {
+		"node_modules/@esbuild/sunos-x64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
 			"integrity": "sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/win32-arm64": {
+		"node_modules/@esbuild/win32-arm64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
 			"integrity": "sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/win32-ia32": {
+		"node_modules/@esbuild/win32-ia32": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
 			"integrity": "sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==",
+			"cpu": [
+				"ia32"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@esbuild/win32-x64": {
+		"node_modules/@esbuild/win32-x64": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
 			"integrity": "sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
-		"@lezer/common": {
+		"node_modules/@lezer/common": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
 			"integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
 			"dev": true
 		},
-		"@lezer/highlight": {
+		"node_modules/@lezer/highlight": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
 			"integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@lezer/common": "^1.0.0"
 			}
 		},
-		"@lezer/lr": {
+		"node_modules/@lezer/lr": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
 			"integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@lezer/common": "^1.0.0"
 			}
 		},
-		"@marijn/find-cluster-break": {
+		"node_modules/@marijn/find-cluster-break": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true
 		},
-		"@nodelib/fs.scandir": {
+		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"@nodelib/fs.stat": {
+		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
 		},
-		"@nodelib/fs.walk": {
+		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"@types/codemirror": {
+		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
 			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/tern": "*"
 			}
 		},
-		"@types/estree": {
+		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true
 		},
-		"@types/json-schema": {
+		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
-		"@types/node": {
+		"node_modules/@types/node": {
 			"version": "16.18.98",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.98.tgz",
 			"integrity": "sha512-fpiC20NvLpTLAzo3oVBKIqBGR6Fx/8oAK/SSf7G+fydnXMY1x4x9RZ6sBXhqKlCU21g2QapUsbLlhv3+a7wS+Q==",
 			"dev": true
 		},
-		"@types/tern": {
+		"node_modules/@types/tern": {
 			"version": "0.23.9",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
 			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/estree": "*"
 			}
 		},
-		"@typescript-eslint/eslint-plugin": {
+		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
 			"integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.29.0",
 				"@typescript-eslint/type-utils": "5.29.0",
 				"@typescript-eslint/utils": "5.29.0",
@@ -300,53 +525,113 @@
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^5.0.0",
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/parser": {
+		"node_modules/@typescript-eslint/parser": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
 			"integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.29.0",
 				"@typescript-eslint/types": "5.29.0",
 				"@typescript-eslint/typescript-estree": "5.29.0",
 				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/scope-manager": {
+		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
 			"integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.29.0",
 				"@typescript-eslint/visitor-keys": "5.29.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"@typescript-eslint/type-utils": {
+		"node_modules/@typescript-eslint/type-utils": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
 			"integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/utils": "5.29.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/types": {
+		"node_modules/@typescript-eslint/types": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
 			"integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
 		},
-		"@typescript-eslint/typescript-estree": {
+		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
 			"integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.29.0",
 				"@typescript-eslint/visitor-keys": "5.29.0",
 				"debug": "^4.3.4",
@@ -354,83 +639,142 @@
 				"is-glob": "^4.0.3",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/utils": {
+		"node_modules/@typescript-eslint/utils": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.29.0.tgz",
 			"integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"@typescript-eslint/scope-manager": "5.29.0",
 				"@typescript-eslint/types": "5.29.0",
 				"@typescript-eslint/typescript-estree": "5.29.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"@typescript-eslint/visitor-keys": {
+		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
 			"integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.29.0",
 				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"array-union": {
+		"node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"braces": {
+		"node_modules/braces": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"builtin-modules": {
+		"node_modules/builtin-modules": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"crelt": {
+		"node_modules/crelt": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true
 		},
-		"debug": {
+		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
-		"dir-glob": {
+		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"esbuild": {
+		"node_modules/esbuild": {
 			"version": "0.17.3",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.3.tgz",
 			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
 			"dev": true,
-			"requires": {
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
 				"@esbuild/android-arm": "0.17.3",
 				"@esbuild/android-arm64": "0.17.3",
 				"@esbuild/android-x64": "0.17.3",
@@ -455,301 +799,440 @@
 				"@esbuild/win32-x64": "0.17.3"
 			}
 		},
-		"eslint-scope": {
+		"node_modules/eslint-scope": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
-		"eslint-utils": {
+		"node_modules/eslint-utils": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
 			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"eslint-visitor-keys": "^2.0.0"
 			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-					"dev": true
-				}
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
 			}
 		},
-		"eslint-visitor-keys": {
+		"node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
 			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
 		},
-		"esrecurse": {
+		"node_modules/esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
-		"estraverse": {
+		"node_modules/esrecurse/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
 		},
-		"fast-glob": {
+		"node_modules/fast-glob": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
 			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
 				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
 			}
 		},
-		"fastq": {
+		"node_modules/fastq": {
 			"version": "1.17.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
 			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"reusify": "^1.0.4"
 			}
 		},
-		"fill-range": {
+		"node_modules/fill-range": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"functional-red-black-tree": {
+		"node_modules/functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
-		"glob-parent": {
+		"node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"globby": {
+		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
 				"fast-glob": "^3.2.9",
 				"ignore": "^5.2.0",
 				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"ignore": {
+		"node_modules/ignore": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
 			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
 		},
-		"is-extglob": {
+		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"is-glob": {
+		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
-		"is-number": {
+		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
 		},
-		"lru-cache": {
+		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"merge2": {
+		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
 		},
-		"micromatch": {
+		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
-		"moment": {
+		"node_modules/moment": {
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
 			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
 		},
-		"ms": {
+		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
-		"obsidian": {
+		"node_modules/obsidian": {
 			"version": "1.8.7",
 			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
 			"integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
 			}
 		},
-		"path-type": {
+		"node_modules/path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"picomatch": {
+		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
-		"queue-microtask": {
+		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
-		"regexpp": {
+		"node_modules/regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
 		},
-		"reusify": {
+		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
 		},
-		"run-parallel": {
+		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
 			"dev": true,
-			"requires": {
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"semver": {
+		"node_modules/semver": {
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
 			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"slash": {
+		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"style-mod": {
+		"node_modules/style-mod": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
 			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
 			"dev": true
 		},
-		"to-regex-range": {
+		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
-		"tslib": {
+		"node_modules/tslib": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
-		"tsutils": {
+		"node_modules/tsutils": {
 			"version": "3.21.0",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
 			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"tslib": "^1.8.1"
 			},
-			"dependencies": {
-				"tslib": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">= 6"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
 		},
-		"typescript": {
+		"node_modules/tsutils/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true
+		},
+		"node_modules/typescript": {
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
 			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
 		},
-		"w3c-keyname": {
+		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true
 		},
-		"yallist": {
+		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "iconic",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Customize your icons and their colors directly from the UI, including tabs, files & folders, bookmarks, tags, properties, and ribbon commands.",
 	"main": "main.js",
 	"scripts": {

--- a/src/managers/EditorIconManager.ts
+++ b/src/managers/EditorIconManager.ts
@@ -317,13 +317,23 @@ export default class EditorIconManager extends IconManager {
 		if (!propListEl) return;
 		const propEls = propListEl.findAll(':scope > .metadata-property');
 
+
 		for (const propEl of propEls) {
-			const prop = props.find(prop => prop.id === propEl.dataset.propertyKey);
-			if (!prop) return;
+			const propId = propEl.dataset.propertyKey;
+			if (!propId) continue;
+			
+			// Use case-insensitive matching to find the property
+			const prop = props.find(p => p.id.toLowerCase() === propId.toLowerCase());
+			
+			
+			if (!prop) continue;
 
 			const keyEl = propEl.find(':scope > .metadata-property-key');
 			const iconEl = keyEl?.find(':scope > .metadata-property-icon');
-			if (iconEl) this.refreshIcon(prop, iconEl);
+			
+			if (iconEl) {
+				this.refreshIcon(prop, iconEl);
+			}
 		}
 	}
 

--- a/src/managers/PropertyIconManager.ts
+++ b/src/managers/PropertyIconManager.ts
@@ -7,12 +7,13 @@ import IconPicker from 'src/dialogs/IconPicker';
  * Handles icons in the Properties pane.
  */
 export default class PropertyIconManager extends IconManager {
-	private containerEl: HTMLElement;
+	private containerEl: HTMLElement | null = null;
+	private propertyViewContainerEl: HTMLElement | null = null;
 
 	constructor(plugin: IconicPlugin) {
 		super(plugin);
 		this.plugin.registerEvent(this.app.workspace.on('layout-change', () => {
-			if (activeDocument.contains(this.containerEl)) {
+			if (this.containerEl && activeDocument.contains(this.containerEl)) {
 				return;
 			} else {
 				this.app.workspace.iterateAllLeaves(leaf => this.manageLeaf(leaf));
@@ -25,25 +26,47 @@ export default class PropertyIconManager extends IconManager {
 	 * Start managing this leaf if has a matching type.
 	 */
 	private manageLeaf(leaf: WorkspaceLeaf): void {
-		// Check if this is a Properties pane by looking for the properties container
+		// Check if this is a Properties pane (note editor) by looking for the properties container
 		const propertiesContainer = leaf.view.containerEl.find('.metadata-properties');
-		if (!propertiesContainer) return;
-		
-
-		this.stopMutationObserver(this.containerEl);
-		this.containerEl = propertiesContainer;
-		this.setMutationObserver(this.containerEl, {
-			subtree: true,
-			childList: true,
-		}, mutation => {
-			for (const addedNode of mutation.addedNodes) {
-				if (addedNode instanceof HTMLElement && addedNode.hasClass('tree-item')) {
-					this.refreshIcons();
-					return;
-				}
+		if (propertiesContainer) {
+			if (this.containerEl) {
+				this.stopMutationObserver(this.containerEl);
 			}
-		});
-		this.refreshIcons();
+			this.containerEl = propertiesContainer;
+			this.setMutationObserver(this.containerEl, {
+				subtree: true,
+				childList: true,
+			}, mutation => {
+				for (const addedNode of mutation.addedNodes) {
+					if (addedNode instanceof HTMLElement && addedNode.hasClass('tree-item')) {
+						this.refreshIcons();
+						return;
+					}
+				}
+			});
+			this.refreshIcons();
+		}
+
+		// Check if this is a PropertyView (core plugin) by looking for view-content with tree-items
+		const viewContent = leaf.view.containerEl.find('.view-content');
+		if (viewContent && viewContent.find('.tree-item')) {
+			if (this.propertyViewContainerEl) {
+				this.stopMutationObserver(this.propertyViewContainerEl);
+			}
+			this.propertyViewContainerEl = viewContent;
+			this.setMutationObserver(this.propertyViewContainerEl, {
+				subtree: true,
+				childList: true,
+			}, mutation => {
+				for (const addedNode of mutation.addedNodes) {
+					if (addedNode instanceof HTMLElement && addedNode.hasClass('tree-item')) {
+						this.refreshIcons();
+						return;
+					}
+				}
+			});
+			this.refreshIcons();
+		}
 	}
 
 	/**
@@ -51,10 +74,16 @@ export default class PropertyIconManager extends IconManager {
 	 * Refresh all property icons.
 	 */
 	refreshIcons(unloading?: boolean): void {
-		this.stopMutationObserver(this.containerEl);
-		const itemEls = this.containerEl?.findAll('.metadata-property') ?? [];
-
-		for (const itemEl of itemEls) {
+		if (this.containerEl) {
+			this.stopMutationObserver(this.containerEl);
+		}
+		if (this.propertyViewContainerEl) {
+			this.stopMutationObserver(this.propertyViewContainerEl);
+		}
+		
+		// Handle note editor properties (metadata-property elements)
+		const metadataItemEls = this.containerEl?.findAll('.metadata-property') ?? [];
+		for (const itemEl of metadataItemEls) {
 			itemEl.addClass('iconic-item');
 
 			const domPropertyName = itemEl.dataset.propertyKey;
@@ -101,11 +130,72 @@ export default class PropertyIconManager extends IconManager {
 			}
 		}
 
+		// Handle PropertyView tree items (core plugin's property view)
+		const treeItemEls = this.propertyViewContainerEl?.findAll('.tree-item') ?? [];
+		for (const itemEl of treeItemEls) {
+			itemEl.addClass('iconic-item');
+
+			// Get property name from tree-item-inner-text
+			const textEl = itemEl.find('.tree-item-inner-text');
+			const domPropertyName = textEl?.textContent?.trim();
+			
+			if (!domPropertyName) continue;
+			
+			// Use user's settings as the single source of truth
+			const settingsKeys = Object.keys(this.plugin.settings.propertyIcons);
+			const matchingKey = settingsKeys.find(key => key.toLowerCase() === domPropertyName.toLowerCase());
+			
+			if (!matchingKey) continue; // Skip properties user hasn't configured icons for
+			
+			// Create property item using user's actual casing from settings
+			const prop: PropertyItem = {
+				id: matchingKey,
+				name: matchingKey,
+				category: 'property' as const,
+				iconDefault: 'lucide-file-question',
+				icon: unloading ? null : this.plugin.settings.propertyIcons[matchingKey]?.icon ?? null,
+				color: unloading ? null : this.plugin.settings.propertyIcons[matchingKey]?.color ?? null,
+				type: null
+			};
+
+			const iconEl = itemEl.find('.tree-item-icon');
+			if (!iconEl) continue;
+
+			if (prop) {
+				if (this.plugin.isSettingEnabled('clickableIcons')) {
+					this.refreshIcon(prop, iconEl, event => {
+						IconPicker.openSingle(this.plugin, prop!, (newIcon, newColor) => {
+							this.plugin.savePropertyIcon(prop!, newIcon, newColor);
+							this.plugin.refreshManagers('property');
+						});
+						event.stopPropagation();
+					});
+				} else {
+					this.refreshIcon(prop, iconEl);
+				}
+
+				if (this.plugin.settings.showMenuActions) {
+					this.setEventListener(itemEl, 'contextmenu', () => this.onContextMenu(prop!.id), { capture: true });
+				} else {
+					this.stopEventListener(itemEl, 'contextmenu');
+				}
+			}
+		}
+
 		
-		this.setMutationsObserver(this.containerEl, {
-			subtree: true,
-			childList: true,
-		}, () => this.refreshIcons());
+		if (this.containerEl) {
+			this.setMutationsObserver(this.containerEl, {
+				subtree: true,
+				childList: true,
+			}, () => this.refreshIcons());
+		}
+		
+		if (this.propertyViewContainerEl) {
+			this.setMutationsObserver(this.propertyViewContainerEl, {
+				subtree: true,
+				childList: true,
+			}, () => this.refreshIcons());
+		}
 	}
 
 	/**
@@ -117,7 +207,7 @@ export default class PropertyIconManager extends IconManager {
 		const clickedProp: PropertyItem = this.plugin.getPropertyItem(clickedPropId);
 		const selectedProps: PropertyItem[] = [];
 
-		for (const selfEl of this.containerEl?.findAll('.tree-item-self.is-selected') ?? []) {
+		for (const selfEl of (this.containerEl?.findAll('.tree-item-self.is-selected') ?? []).concat(this.propertyViewContainerEl?.findAll('.tree-item-self.is-selected') ?? [])) {
 			const textEl = selfEl.find(':scope > .tree-item-inner > .tree-item-inner-text');
 			if (textEl?.textContent) {
 				selectedProps.push(this.plugin.getPropertyItem(textEl.textContent));

--- a/styles.css
+++ b/styles.css
@@ -143,16 +143,6 @@ a.tag {
 	font-size: inherit;
 }
 
-/* Make wrapper match Obsidian's readable line width content div behavior */
-.markdown-preview-view.is-readable-line-width .markdown-preview-sizer .iconic-title-wrapper,
-.markdown-preview-view.is-readable-line-width .markdown-preview-sizer > .iconic-title-wrapper,
-.markdown-preview-view.is-readable-line-width .markdown-preview-sizer > div > .iconic-title-wrapper,
-.markdown-source-view.is-readable-line-width .cm-sizer > .iconic-title-wrapper {
-	max-width: var(--file-line-width) !important;
-	margin-left: var(--content-margin-start) !important;
-	margin-right: auto !important;
-}
-
 /* Editor properties */
 .iconic-clickable-icons .metadata-property-icon.iconic-icon:hover {
 	cursor: var(--cursor-link);

--- a/styles.css
+++ b/styles.css
@@ -143,6 +143,16 @@ a.tag {
 	font-size: inherit;
 }
 
+/* Make wrapper match Obsidian's readable line width content div behavior */
+.markdown-preview-view.is-readable-line-width .markdown-preview-sizer .iconic-title-wrapper,
+.markdown-preview-view.is-readable-line-width .markdown-preview-sizer > .iconic-title-wrapper,
+.markdown-preview-view.is-readable-line-width .markdown-preview-sizer > div > .iconic-title-wrapper,
+.markdown-source-view.is-readable-line-width .cm-sizer > .iconic-title-wrapper {
+	max-width: var(--file-line-width) !important;
+	margin-left: var(--content-margin-start) !important;
+	margin-right: auto !important;
+}
+
 /* Editor properties */
 .iconic-clickable-icons .metadata-property-icon.iconic-icon:hover {
 	cursor: var(--cursor-link);


### PR DESCRIPTION
- Fix case mismatch between DOM property names and settings
- Update PropertyIconManager to properly detect Properties pane using .metadata-property
- Add robust property name matching with multiple case variations
- Fix sidebar icon API version check for Obsidian 1.10.0+ compatibility
- Add error handling for getWidget calls to prevent undefined errors
- Removed hardcoded property type icon names via @unxok's PR (#175)