### PR TITLE
Update 'save' translation from 'Abbrechen' to 'Speichern'

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -41,7 +41,7 @@
 		"emojis": "Emojis",
 		"mixed": "Gemischt",
 		"cancel": "Entfernen",
-		"save": "Abbrechen",
+		"save": "Speichern",
 		"colors": {
 			"red": "Rot",
 			"orange": "Orange",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -40,7 +40,7 @@
 		"icons": "Symbole",
 		"emojis": "Emojis",
 		"mixed": "Gemischt",
-		"cancel": "Entfernen",
+		"cancel": "Abbrechen",
 		"save": "Speichern",
 		"colors": {
 			"red": "Rot",


### PR DESCRIPTION
German translation of "Save" is very wrong as "Abbrechen" means "Cancel".