### PR TITLE
feat: folder notes integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,33 @@
 {
 	"name": "iconic",
 	"version": "1.1.8",
-	"lockfileVersion": 1,
+	"lockfileVersion": 3,
 	"requires": true,
-	"dependencies": {
-		"@codemirror/language": {
+	"packages": {
+		"": {
+			"name": "iconic",
+			"version": "1.1.8",
+			"license": "MIT-0",
+			"devDependencies": {
+				"@codemirror/language": "^6.11.2",
+				"@codemirror/state": "^6.5.0",
+				"@codemirror/view": "^6.38.0",
+				"@types/node": "^16.18.98",
+				"@typescript-eslint/eslint-plugin": "5.29.0",
+				"@typescript-eslint/parser": "5.29.0",
+				"builtin-modules": "3.3.0",
+				"esbuild": "^0.27.0",
+				"obsidian": "^1.11.4",
+				"tslib": "2.4.0",
+				"typescript": "4.7.4"
+			}
+		},
+		"node_modules/@codemirror/language": {
 			"version": "6.11.2",
 			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.2.tgz",
 			"integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
 				"@lezer/common": "^1.1.0",
@@ -18,307 +36,550 @@
 				"style-mod": "^4.0.0"
 			}
 		},
-		"@codemirror/state": {
+		"node_modules/@codemirror/state": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
 			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
 		},
-		"@codemirror/view": {
+		"node_modules/@codemirror/view": {
 			"version": "6.38.6",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
 			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@codemirror/state": "^6.5.0",
 				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
 			}
 		},
-		"@esbuild/aix-ppc64": {
+		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
 			"integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+			"cpu": [
+				"ppc64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/android-arm": {
+		"node_modules/@esbuild/android-arm": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
 			"integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+			"cpu": [
+				"arm"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/android-arm64": {
+		"node_modules/@esbuild/android-arm64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
 			"integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/android-x64": {
+		"node_modules/@esbuild/android-x64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
 			"integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/darwin-arm64": {
+		"node_modules/@esbuild/darwin-arm64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
 			"integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/darwin-x64": {
+		"node_modules/@esbuild/darwin-x64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
 			"integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/freebsd-arm64": {
+		"node_modules/@esbuild/freebsd-arm64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
 			"integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/freebsd-x64": {
+		"node_modules/@esbuild/freebsd-x64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
 			"integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/linux-arm": {
+		"node_modules/@esbuild/linux-arm": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
 			"integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+			"cpu": [
+				"arm"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/linux-arm64": {
+		"node_modules/@esbuild/linux-arm64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
 			"integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/linux-ia32": {
+		"node_modules/@esbuild/linux-ia32": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
 			"integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+			"cpu": [
+				"ia32"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/linux-loong64": {
+		"node_modules/@esbuild/linux-loong64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
 			"integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+			"cpu": [
+				"loong64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/linux-mips64el": {
+		"node_modules/@esbuild/linux-mips64el": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
 			"integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+			"cpu": [
+				"mips64el"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/linux-ppc64": {
+		"node_modules/@esbuild/linux-ppc64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
 			"integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+			"cpu": [
+				"ppc64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/linux-riscv64": {
+		"node_modules/@esbuild/linux-riscv64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
 			"integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+			"cpu": [
+				"riscv64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/linux-s390x": {
+		"node_modules/@esbuild/linux-s390x": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
 			"integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+			"cpu": [
+				"s390x"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/linux-x64": {
+		"node_modules/@esbuild/linux-x64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
 			"integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/netbsd-arm64": {
+		"node_modules/@esbuild/netbsd-arm64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
 			"integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/netbsd-x64": {
+		"node_modules/@esbuild/netbsd-x64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
 			"integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/openbsd-arm64": {
+		"node_modules/@esbuild/openbsd-arm64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
 			"integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/openbsd-x64": {
+		"node_modules/@esbuild/openbsd-x64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
 			"integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/openharmony-arm64": {
+		"node_modules/@esbuild/openharmony-arm64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
 			"integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/sunos-x64": {
+		"node_modules/@esbuild/sunos-x64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
 			"integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/win32-arm64": {
+		"node_modules/@esbuild/win32-arm64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
 			"integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/win32-ia32": {
+		"node_modules/@esbuild/win32-ia32": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
 			"integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+			"cpu": [
+				"ia32"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@esbuild/win32-x64": {
+		"node_modules/@esbuild/win32-x64": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
 			"integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
 		},
-		"@lezer/common": {
+		"node_modules/@lezer/common": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
 			"integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
 			"dev": true
 		},
-		"@lezer/highlight": {
+		"node_modules/@lezer/highlight": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
 			"integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@lezer/common": "^1.0.0"
 			}
 		},
-		"@lezer/lr": {
+		"node_modules/@lezer/lr": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
 			"integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@lezer/common": "^1.0.0"
 			}
 		},
-		"@marijn/find-cluster-break": {
+		"node_modules/@marijn/find-cluster-break": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true
 		},
-		"@nodelib/fs.scandir": {
+		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"@nodelib/fs.stat": {
+		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
 		},
-		"@nodelib/fs.walk": {
+		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"@types/codemirror": {
+		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
 			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/tern": "*"
 			}
 		},
-		"@types/estree": {
+		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true
 		},
-		"@types/json-schema": {
+		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
-		"@types/node": {
+		"node_modules/@types/node": {
 			"version": "16.18.98",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.98.tgz",
 			"integrity": "sha512-fpiC20NvLpTLAzo3oVBKIqBGR6Fx/8oAK/SSf7G+fydnXMY1x4x9RZ6sBXhqKlCU21g2QapUsbLlhv3+a7wS+Q==",
 			"dev": true
 		},
-		"@types/tern": {
+		"node_modules/@types/tern": {
 			"version": "0.23.9",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
 			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/estree": "*"
 			}
 		},
-		"@typescript-eslint/eslint-plugin": {
+		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
 			"integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.29.0",
 				"@typescript-eslint/type-utils": "5.29.0",
 				"@typescript-eslint/utils": "5.29.0",
@@ -328,53 +589,113 @@
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^5.0.0",
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/parser": {
+		"node_modules/@typescript-eslint/parser": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
 			"integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.29.0",
 				"@typescript-eslint/types": "5.29.0",
 				"@typescript-eslint/typescript-estree": "5.29.0",
 				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/scope-manager": {
+		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
 			"integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.29.0",
 				"@typescript-eslint/visitor-keys": "5.29.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"@typescript-eslint/type-utils": {
+		"node_modules/@typescript-eslint/type-utils": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
 			"integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/utils": "5.29.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/types": {
+		"node_modules/@typescript-eslint/types": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
 			"integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
 		},
-		"@typescript-eslint/typescript-estree": {
+		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
 			"integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.29.0",
 				"@typescript-eslint/visitor-keys": "5.29.0",
 				"debug": "^4.3.4",
@@ -382,83 +703,142 @@
 				"is-glob": "^4.0.3",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/utils": {
+		"node_modules/@typescript-eslint/utils": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.29.0.tgz",
 			"integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"@typescript-eslint/scope-manager": "5.29.0",
 				"@typescript-eslint/types": "5.29.0",
 				"@typescript-eslint/typescript-estree": "5.29.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"@typescript-eslint/visitor-keys": {
+		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
 			"integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.29.0",
 				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"array-union": {
+		"node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"braces": {
+		"node_modules/braces": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"builtin-modules": {
+		"node_modules/builtin-modules": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"crelt": {
+		"node_modules/crelt": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true
 		},
-		"debug": {
+		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
-		"dir-glob": {
+		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"esbuild": {
+		"node_modules/esbuild": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
 			"integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
 			"dev": true,
-			"requires": {
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
 				"@esbuild/aix-ppc64": "0.27.0",
 				"@esbuild/android-arm": "0.27.0",
 				"@esbuild/android-arm64": "0.27.0",
@@ -487,301 +867,440 @@
 				"@esbuild/win32-x64": "0.27.0"
 			}
 		},
-		"eslint-scope": {
+		"node_modules/eslint-scope": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
-		"eslint-utils": {
+		"node_modules/eslint-utils": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
 			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"eslint-visitor-keys": "^2.0.0"
 			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-					"dev": true
-				}
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
 			}
 		},
-		"eslint-visitor-keys": {
+		"node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
 			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
 		},
-		"esrecurse": {
+		"node_modules/esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
-		"estraverse": {
+		"node_modules/esrecurse/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
 		},
-		"fast-glob": {
+		"node_modules/fast-glob": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
 			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
 				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
 			}
 		},
-		"fastq": {
+		"node_modules/fastq": {
 			"version": "1.17.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
 			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"reusify": "^1.0.4"
 			}
 		},
-		"fill-range": {
+		"node_modules/fill-range": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"functional-red-black-tree": {
+		"node_modules/functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
-		"glob-parent": {
+		"node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"globby": {
+		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
 				"fast-glob": "^3.2.9",
 				"ignore": "^5.2.0",
 				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"ignore": {
+		"node_modules/ignore": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
 			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
 		},
-		"is-extglob": {
+		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"is-glob": {
+		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
-		"is-number": {
+		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
 		},
-		"lru-cache": {
+		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"merge2": {
+		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
 		},
-		"micromatch": {
+		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
-		"moment": {
+		"node_modules/moment": {
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
 			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
 		},
-		"ms": {
+		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
-		"obsidian": {
+		"node_modules/obsidian": {
 			"version": "1.11.4",
 			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.11.4.tgz",
 			"integrity": "sha512-n0KD3S+VndgaByrEtEe8NELy0ya6/s+KZ7OcxA6xOm5NN4thxKpQjo6eqEudHEvfGCeT/TYToAKJzitQ1I3XTg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "6.5.0",
+				"@codemirror/view": "6.38.6"
 			}
 		},
-		"path-type": {
+		"node_modules/path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"picomatch": {
+		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
-		"queue-microtask": {
+		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
-		"regexpp": {
+		"node_modules/regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
 		},
-		"reusify": {
+		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
 		},
-		"run-parallel": {
+		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
 			"dev": true,
-			"requires": {
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"semver": {
+		"node_modules/semver": {
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
 			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"slash": {
+		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"style-mod": {
+		"node_modules/style-mod": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
 			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
 			"dev": true
 		},
-		"to-regex-range": {
+		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
-		"tslib": {
+		"node_modules/tslib": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
-		"tsutils": {
+		"node_modules/tsutils": {
 			"version": "3.21.0",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
 			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"tslib": "^1.8.1"
 			},
-			"dependencies": {
-				"tslib": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">= 6"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
 		},
-		"typescript": {
+		"node_modules/tsutils/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true
+		},
+		"node_modules/typescript": {
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
 			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
 		},
-		"w3c-keyname": {
+		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true
 		},
-		"yallist": {
+		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",

--- a/src/IconicPlugin.ts
+++ b/src/IconicPlugin.ts
@@ -106,6 +106,7 @@ interface IconicSettings {
 	uncolorQuick: boolean;
 	rememberDeletedItems: boolean;
 	maxBackups: number;
+	integrateFolderNotes: boolean;
 	dialogState: {
 		iconMode: boolean;
 		emojiMode: boolean;
@@ -170,6 +171,7 @@ const DEFAULT_SETTINGS: IconicSettings = {
 	uncolorQuick: false,
 	rememberDeletedItems: false,
 	maxBackups: 5,
+	integrateFolderNotes: false,
 	dialogState: {
 		iconMode: true,
 		emojiMode: false,

--- a/src/IconicSettingTab.ts
+++ b/src/IconicSettingTab.ts
@@ -1,4 +1,4 @@
-import { ExtraButtonComponent, normalizePath, Platform, PluginSettingTab, SettingGroup } from 'obsidian';
+import { ExtraButtonComponent, normalizePath, Platform, PluginSettingTab, Setting } from 'obsidian';
 import IconicPlugin, { STRINGS } from 'src/IconicPlugin';
 import RulePicker from 'src/dialogs/RulePicker';
 
@@ -28,11 +28,8 @@ export default class IconicSettingTab extends PluginSettingTab {
 	display(): void {
 		this.containerEl.empty();
 
-		// GROUP: Top
-		const groupTop = new SettingGroup(this.containerEl);
-
 		// SETTING: Rules
-		groupTop.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.rulebook.name)
 			.setDesc(STRINGS.settings.rulebook.desc)
 			.addButton(button => { button
@@ -44,11 +41,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.app.setting.close();
 					RulePicker.open(this.plugin);
 				});
-			})
-		);
+			});
 
 		// SETTING: Bigger icons
-		groupTop.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.biggerIcons.name)
 			.setDesc(STRINGS.settings.biggerIcons.desc)
 			.addExtraButton(indicator => {
@@ -68,11 +64,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.refreshBody();
 				});
 				this.refreshIndicator(this.indicators.biggerIcons, dropdown.getValue());
-			})
-		);
+			});
 
 		// SETTING: Clickable icons
-		groupTop.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(Platform.isDesktop
 				? STRINGS.settings.clickableIcons.nameDesktop
 				: STRINGS.settings.clickableIcons.nameMobile
@@ -99,15 +94,13 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.refreshBody();
 				});
 				this.refreshIndicator(this.indicators.clickableIcons, dropdown.getValue());
-			})
-		);
+			});
 
 		// GROUP: Sidebars & tabs
-		const groupSidebarsAndTabs = new SettingGroup(this.containerEl)
-			.setHeading(STRINGS.settings.headingSidebarsAndTabs);
+		this.containerEl.createEl('h2', { text: STRINGS.settings.headingSidebarsAndTabs });
 
 		// SETTING: Show all file icons
-		groupSidebarsAndTabs.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showAllFileIcons.name)
 			.setDesc(STRINGS.settings.showAllFileIcons.desc)
 			.addToggle(toggle => toggle
@@ -117,11 +110,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshManagers('file');
 				})
-			)
-		);
+			);
 
 		// SETTING: Show all folder icons
-		groupSidebarsAndTabs.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showAllFolderIcons.name)
 			.setDesc(STRINGS.settings.showAllFolderIcons.desc)
 			.addToggle(toggle => toggle
@@ -131,11 +123,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshManagers('folder');
 				})
-			)
-		);
+			);
 
 		// SETTING: Minimal folder icons
-		groupSidebarsAndTabs.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.minimalFolderIcons.name)
 			.setDesc(STRINGS.settings.minimalFolderIcons.desc)
 			.addToggle(toggle => toggle
@@ -145,11 +136,23 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshManagers('folder');
 				})
-			)
-		);
+			);
+
+		// SETTING: Folder Notes integration
+		new Setting(this.containerEl)
+			.setName(STRINGS.settings.integrateFolderNotes.name)
+			.setDesc(STRINGS.settings.integrateFolderNotes.desc)
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.integrateFolderNotes)
+				.onChange(value => {
+					this.plugin.settings.integrateFolderNotes = value;
+					this.plugin.saveSettings();
+					this.plugin.refreshManagers('file');
+				})
+			);
 
 		// SETTING: Show Markdown tab icons
-		groupSidebarsAndTabs.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showMarkdownTabIcons.name)
 			.setDesc(STRINGS.settings.showMarkdownTabIcons.desc)
 			.addToggle(toggle => toggle
@@ -159,15 +162,13 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshBody();
 				})
-			)
-		);
+			);
 
 		// GROUP: Editor
-		const groupEditor = new SettingGroup(this.containerEl)
-			.setHeading(STRINGS.settings.headingEditor);
+		this.containerEl.createEl('h2', { text: STRINGS.settings.headingEditor });
 
 		// SETTING: Show title icons
-		groupEditor.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showTitleIcons.name)
 			.setDesc(STRINGS.settings.showTitleIcons.desc)
 			.addToggle(toggle => toggle
@@ -177,11 +178,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshManagers('file');
 				})
-			)
-		);
+			);
 
 		// SETTING: Show tag pill icons
-		groupEditor.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showTagPillIcons.name)
 			.setDesc(STRINGS.settings.showTagPillIcons.desc)
 			.addToggle(toggle => toggle
@@ -191,15 +191,13 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshManagers('tag');
 				})
-			)
-		);
+			);
 
 		// GROUP: Menus & dialogs
-		const groupMenusAndDialogs = new SettingGroup(this.containerEl)
-			.setHeading(STRINGS.settings.headingMenusAndDialogs);
+		this.containerEl.createEl('h2', { text: STRINGS.settings.headingMenusAndDialogs });
 
 		// SETTING: Show menu actions
-		groupMenusAndDialogs.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showMenuActions.name)
 			.setDesc(STRINGS.settings.showMenuActions.desc)
 			.addToggle(toggle => toggle
@@ -209,11 +207,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshManagers();
 				})
-			)
-		);
+			);
 
 		// SETTING: Show suggestion icons
-		groupMenusAndDialogs.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showSuggestionIcons.name)
 			.setDesc(STRINGS.settings.showSuggestionIcons.desc)
 			.addToggle(toggle => toggle
@@ -222,11 +219,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.settings.showSuggestionIcons = value;
 					this.plugin.saveSettings();
 				})
-			)
-		);
+			);
 
 		// SETTING: Show quick switcher icons
-		groupMenusAndDialogs.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showQuickSwitcherIcons.name)
 			.setDesc(STRINGS.settings.showQuickSwitcherIcons.desc)
 			.addToggle(toggle => toggle
@@ -235,11 +231,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.settings.showQuickSwitcherIcons = value;
 					this.plugin.saveSettings();
 				})
-			)
-		);
+			);
 
 		// SETTING: Show "Move file" dialog icons
-		groupMenusAndDialogs.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showMoveFileIcons.name)
 			.setDesc(STRINGS.settings.showMoveFileIcons.desc)
 			.addToggle(toggle => toggle
@@ -248,15 +243,13 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.settings.showMoveFileIcons = value;
 					this.plugin.saveSettings();
 				})
-			)
-		);
+			);
 
 		// GROUP: Icon picker
-		const groupIconPicker = new SettingGroup(this.containerEl)
-			.setHeading(STRINGS.settings.headingIconPicker);
+		this.containerEl.createEl('h2', { text: STRINGS.settings.headingIconPicker });
 
 		// SETTING: Show item name
-		groupIconPicker.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.showItemName.name)
 			.setDesc(STRINGS.settings.showItemName.desc)
 			.addExtraButton(indicator => {
@@ -275,11 +268,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 				});
 				this.refreshIndicator(this.indicators.showItemName, dropdown.getValue());
-			})
-		);
+			});
 
 		// SETTING: Bigger search results
-		groupIconPicker.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.biggerSearchResults.name)
 			.setDesc(STRINGS.settings.biggerSearchResults.desc)
 			.addExtraButton(indicator => {
@@ -299,11 +291,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.refreshBody();
 				});
 				this.refreshIndicator(this.indicators.biggerSearchResults, dropdown.getValue());
-			})
-		);
+			});
 
 		// SETTING: Max search results
-		groupIconPicker.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.maxSearchResults.name)
 			.setDesc(STRINGS.settings.maxSearchResults.desc)
 			.addSlider(slider => slider
@@ -314,11 +305,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.settings.maxSearchResults = value;
 					this.plugin.saveSettings();
 				})
-			)
-		);
+			);
 
 		// SETTING: Main color picker
-		groupIconPicker.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.colorPicker1.name)
 			.setDesc(Platform.isDesktop
 				? STRINGS.settings.colorPicker1.descDesktop
@@ -338,11 +328,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 				})
 				this.refreshIndicator(this.indicators.colorPicker1, dropdown.getValue());
-			})
-		);
+			});
 
 		// SETTING: Second color picker
-		groupIconPicker.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.colorPicker2.name)
 			.setDesc(Platform.isDesktop
 				? STRINGS.settings.colorPicker2.descDesktop
@@ -362,15 +351,13 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 				});
 				this.refreshIndicator(this.indicators.colorPicker2, dropdown.getValue());
-			})
-		);
+			});
 
 		// GROUP: Advanced
-		const groupAdvanced = new SettingGroup(this.containerEl)
-			.setHeading(STRINGS.settings.headingAdvanced);
+		this.containerEl.createEl('h2', { text: STRINGS.settings.headingAdvanced });
 
 		// SETTING: Colorless hover
-		groupAdvanced.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.uncolorHover.name)
 			.setDesc(STRINGS.settings.uncolorHover.desc)
 			.addToggle(toggle => toggle
@@ -380,11 +367,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshBody();
 				})
-			)
-		);
+			);
 
 		// SETTING: Colorless drag
-		groupAdvanced.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.uncolorDrag.name)
 			.setDesc(STRINGS.settings.uncolorDrag.desc)
 			.addToggle(toggle => toggle
@@ -394,11 +380,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshBody();
 				})
-			)
-		);
+			);
 
 		// SETTING: Colorless selection
-		groupAdvanced.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.uncolorSelect.name)
 			.setDesc(STRINGS.settings.uncolorSelect.desc)
 			.addToggle(toggle => toggle
@@ -408,11 +393,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshBody();
 				})
-			)
-		);
+			);
 
 		// SETTING: Colorless ribbon button
-		groupAdvanced.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.uncolorQuick.name)
 			.setDesc(STRINGS.settings.uncolorQuick.desc)
 			.addToggle(toggle => toggle
@@ -422,11 +406,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 					this.plugin.refreshManagers('ribbon');
 				})
-			)
-		);
+			);
 
 		// SETTING: Remember icons of deleted items
-		groupAdvanced.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.rememberDeletedItems.name)
 			.setDesc(STRINGS.settings.rememberDeletedItems.desc)
 			.addToggle(toggle => toggle
@@ -435,11 +418,10 @@ export default class IconicSettingTab extends PluginSettingTab {
 					this.plugin.settings.rememberDeletedItems = value;
 					this.plugin.saveSettings();
 				})
-			)
-		);
+			);
 
 		// SETTING: Maximum automatic backups
-		groupAdvanced.addSetting(setting => setting
+		new Setting(this.containerEl)
 			.setName(STRINGS.settings.maxBackups.name)
 			.setDesc(STRINGS.settings.maxBackups.desc)
 			.then(setting => {
@@ -465,7 +447,7 @@ export default class IconicSettingTab extends PluginSettingTab {
 				this.plugin.settings.maxBackups = Number(value) || 0;
 				this.plugin.saveSettings();
 			})
-		));
+		);
 	}
 
 	/**

--- a/src/Strings.ts
+++ b/src/Strings.ts
@@ -333,6 +333,10 @@ export default class Strings {
 			name: 'Minimal folder icons',
 			desc: 'Replace folder arrows with your folder icons.',
 		},
+		integrateFolderNotes: {
+			name: 'Folder Notes integration',
+			desc: 'Apply file rules to folders when the matched file is that folder\'s Folder Note.',
+		},
 		showMarkdownTabIcons: {
 			name: 'Show Markdown tab icons',
 			desc: 'Show tab icons for Markdown files.',

--- a/src/managers/FileIconManager.ts
+++ b/src/managers/FileIconManager.ts
@@ -1,5 +1,5 @@
 import { WorkspaceLeaf } from 'obsidian';
-import IconicPlugin, { FileItem, STRINGS } from 'src/IconicPlugin';
+import IconicPlugin, { FileItem, STRINGS, Item } from 'src/IconicPlugin';
 import IconManager from 'src/managers/IconManager';
 import RuleEditor from 'src/dialogs/RuleEditor';
 import IconPicker from 'src/dialogs/IconPicker';
@@ -13,6 +13,10 @@ export default class FileIconManager extends IconManager {
 	 * Tracks pending refresh operations to prevent multiple rapid refreshes when expanding folders.
 	 */
 	private refreshTimerId: number;
+	/**
+	 * Cache for folder → folder-note file path mappings.
+	 */
+	private folderNoteCache = new Map<string, string | null>();
 
 	constructor(plugin: IconicPlugin) {
 		super(plugin);
@@ -62,10 +66,113 @@ export default class FileIconManager extends IconManager {
 	}
 
 	/**
+	 * Clear the folder note cache.
+	 * Call this when the Folder Notes plugin settings might have changed.
+	 */
+	private clearFolderNoteCache(): void {
+		this.folderNoteCache.clear();
+	}
+
+	/**
+	 * Get the path of the folder note for a given folder path.
+	 * Returns null if no folder note exists or Folder Notes plugin is not enabled.
+	 */
+	private getFolderNotePath(folderPath: string): string | null {
+		if (!this.plugin.settings.integrateFolderNotes) return null;
+
+		// Check cache first
+		if (this.folderNoteCache.has(folderPath)) {
+			return this.folderNoteCache.get(folderPath) ?? null;
+		}
+
+		// Get Folder Notes plugin instance
+		// @ts-expect-error accessing other plugin via ID
+		const folderNotes = this.app.plugins.getPlugin('folder-notes');
+		if (!folderNotes) {
+			this.folderNoteCache.set(folderPath, null);
+			return null;
+		}
+
+		let folderNotePath: string | null = null;
+
+		// Check for detached folder note first
+		// Access Folder Notes plugin internals via any type
+		const excludedFolders = (folderNotes as any)?.settings?.excludeFolders ?? [];
+		const detachedFolder = excludedFolders.find((f: any) => f.path === folderPath && f.detached && f.detachedFilePath);
+		if (detachedFolder) {
+			const tFile = this.app.vault.getAbstractFileByPath(detachedFolder.detachedFilePath);
+			if (tFile) {
+				folderNotePath = tFile.path;
+			}
+		}
+
+		// If not detached, compute attached folder note path
+		if (!folderNotePath) {
+			// Access Folder Notes plugin internals via any type
+			const settings = (folderNotes as any)?.settings;
+			if (settings) {
+				const folderNoteName = settings.folderNoteName ?? '{{folder_name}}';
+				const folderNoteType = settings.folderNoteType ?? '.md';
+				const storageLocation = settings.storageLocation ?? 'insideFolder';
+				const supportedFileTypes = settings.supportedFileTypes ?? [];
+
+				const folderName = folderPath.split('/').pop() ?? '';
+				const fileName = folderNoteName.replace('{{folder_name}}', folderName);
+				const noteType = folderNoteType === '.excalidraw' ? '.md' : folderNoteType;
+
+				const possiblePaths: string[] = [];
+
+				if (storageLocation === 'insideFolder') {
+					possiblePaths.push(`${folderPath}/${fileName}${noteType}`);
+				} else if (storageLocation === 'parentFolder') {
+					const parentPath = folderPath.split('/').slice(0, -1).join('/') || '';
+					if (parentPath) {
+						possiblePaths.push(`${parentPath}/${fileName}${noteType}`);
+					} else {
+						possiblePaths.push(`${fileName}${noteType}`);
+					}
+				} else if (storageLocation === 'vaultFolder') {
+					possiblePaths.push(`${fileName}${noteType}`);
+				}
+
+				// Try primary type first, then fallback to supported types
+				for (const path of possiblePaths) {
+					const tFile = this.app.vault.getAbstractFileByPath(path);
+					if (tFile) {
+						folderNotePath = tFile.path;
+						break;
+					}
+				}
+
+				// If no primary type found, try supported file types
+				if (!folderNotePath && supportedFileTypes.length > 0) {
+					for (const type of supportedFileTypes) {
+						if (type === 'excalidraw') continue; // handled as .md
+						const ext = type.startsWith('.') ? type : `.${type}`;
+						for (const basePath of possiblePaths) {
+							const path = basePath.slice(0, -noteType.length) + ext;
+							const tFile = this.app.vault.getAbstractFileByPath(path);
+							if (tFile) {
+								folderNotePath = tFile.path;
+								break;
+							}
+						}
+						if (folderNotePath) break;
+					}
+				}
+			}
+		}
+
+		this.folderNoteCache.set(folderPath, folderNotePath);
+		return folderNotePath;
+	}
+
+	/**
 	 * @override
 	 * Refresh all file icons.
 	 */
 	refreshIcons(unloading?: boolean): void {
+		this.clearFolderNoteCache();
 		const files = this.plugin.getFileItems(unloading);
 		const itemEls = this.containerEl?.findAll(':scope > .tree-item');
 		if (itemEls) this.refreshChildIcons(files, itemEls, unloading);
@@ -84,7 +191,30 @@ export default class FileIconManager extends IconManager {
 
 			// Check for an icon ruling
 			const page = file.items ? 'folder' : 'file';
-			const rule = this.plugin.ruleManager.checkRuling(page, file.id, unloading) ?? file;
+			let rule: Item | null = this.plugin.ruleManager.checkRuling(page, file.id, unloading);
+
+			// For folders, also check folder-note file rulings if no folder rule exists
+			if (file.items && !rule && this.plugin.settings.integrateFolderNotes) {
+				const folderNotePath = this.getFolderNotePath(file.id);
+				if (folderNotePath) {
+					const noteRule = this.plugin.ruleManager.checkRuling('file', folderNotePath, unloading);
+					if (noteRule) {
+						// Use the folder-note rule's icon and color
+						// If noteRule has no icon but has color, synthesize a folder icon
+						if (!noteRule.icon && noteRule.color) {
+							rule = { ...noteRule, iconDefault: 'lucide-folder' };
+						} else {
+							rule = noteRule;
+						}
+					}
+				}
+			}
+
+			// Fall back to file's own icon settings if no rule applies
+			// Precedence: Folder rule > Folder-note rule > Manual folder icon
+			if (!rule) {
+				rule = file;
+			}
 
 			if (file.items) {
 				// Refresh children immediately if folder is expanded
@@ -136,6 +266,11 @@ export default class FileIconManager extends IconManager {
 					}
 				});
 			}
+			// rule is guaranteed to be non-null here
+			const nonNullRule = rule!;
+
+			// Declare display rule (will be set below)
+			let displayRule: Item = nonNullRule;
 
 			// Ensure icon element positioned before filename
 			let iconEl = selfEl.find(':scope > .tree-item-icon') ?? selfEl.createDiv({ cls: 'tree-item-icon' });
@@ -146,16 +281,31 @@ export default class FileIconManager extends IconManager {
 
 			if (file.items) {
 				// Toggle default icon based on expand/collapse state
-				if (file.iconDefault) file.iconDefault = iconEl.hasClass('is-collapsed')
+				// If rule is from folder-note and has iconDefault (color-only case),
+				// use a folder icon based on collapse state
+				let iconDefault = nonNullRule.iconDefault;
+				if (iconDefault === 'lucide-folder') {
+					iconDefault = iconEl.hasClass('is-collapsed')
+						? 'lucide-folder-closed'
+						: 'lucide-folder-open';
+				}
+			// Use file.iconDefault for manual folder icons if rule doesn't provide one
+			if (!iconDefault && file.iconDefault) {
+				iconDefault = iconEl.hasClass('is-collapsed')
 					? 'lucide-folder-closed'
 					: 'lucide-folder-open';
 			}
+			// Create a display rule with the correct iconDefault
+			displayRule = { ...nonNullRule, iconDefault };
+		} else {
+			displayRule = nonNullRule;
+		}
 
 			let folderIconEl = selfEl.find(':scope > .iconic-sidekick:not(.tree-item-icon)');
-			if (this.plugin.settings.minimalFolderIcons || !this.plugin.settings.showAllFolderIcons && !rule.icon && !rule.iconDefault) {
+			if (this.plugin.settings.minimalFolderIcons || !this.plugin.settings.showAllFolderIcons && !displayRule.icon && !displayRule.iconDefault) {
 				folderIconEl?.remove();
 			} else {
-				const arrowColor = rule.icon || rule.iconDefault ? null : rule.color;
+				const arrowColor = displayRule.icon || displayRule.iconDefault ? null : displayRule.color;
 				this.refreshIcon({ icon: null, color: arrowColor }, iconEl);
 				folderIconEl = folderIconEl ?? selfEl.createDiv({ cls: 'iconic-sidekick' });
 				if (iconEl.nextElementSibling !== folderIconEl) {
@@ -164,10 +314,10 @@ export default class FileIconManager extends IconManager {
 				iconEl = folderIconEl;
 			}
 
-			if (iconEl.hasClass('collapse-icon') && !rule.icon && !rule.iconDefault) {
-				this.refreshIcon(rule, iconEl); // Skip click listener if icon will be a collapse arrow
+			if (iconEl.hasClass('collapse-icon') && !displayRule.icon && !displayRule.iconDefault) {
+				this.refreshIcon(displayRule, iconEl); // Skip click listener if icon will be a collapse arrow
 			} else if (this.plugin.isSettingEnabled('clickableIcons')) {
-				this.refreshIcon(rule, iconEl, event => {
+				this.refreshIcon(displayRule, iconEl, event => {
 					IconPicker.openSingle(this.plugin, file, (newIcon, newColor) => {
 						this.plugin.saveFileIcon(file, newIcon, newColor);
 						this.plugin.refreshManagers('file', 'folder');
@@ -175,19 +325,19 @@ export default class FileIconManager extends IconManager {
 					event.stopPropagation();
 				});
 			} else {
-				this.refreshIcon(rule, iconEl);
+				this.refreshIcon(displayRule, iconEl);
 			}
 
 			// Update ghost icon when dragging
 			this.setEventListener(selfEl, 'dragstart', () => {
-				if (rule.icon || rule.iconDefault || rule.color) {
+				if (displayRule.icon || displayRule.iconDefault || displayRule.color) {
 					const ghostEl = selfEl.doc.body.find(':scope > .drag-ghost > .drag-ghost-self');
 					if (ghostEl) {
 						const spanEl = ghostEl.find('span');
-						const ghostIcon = (file.category === 'folder' && rule.icon === null)
+						const ghostIcon = (file.category === 'folder' && displayRule.icon === null)
 							? 'lucide-folder-open'
-							: rule.icon || rule.iconDefault;
-						this.refreshIcon({ icon: ghostIcon, color: rule.color }, ghostEl);
+							: displayRule.icon || displayRule.iconDefault;
+						this.refreshIcon({ icon: ghostIcon, color: displayRule.color }, ghostEl);
 						ghostEl.appendChild(spanEl);
 					}
 				}


### PR DESCRIPTION
Addresses #98 

> [!NOTE]
> This is vibecoded to make it work. Is it efficient? Does it make architectural sense? Not sure. However, it can serve as a starting point for anyone interested, as it's at least an MVP/POC, since it works for my need of adding an icon to a Folder Note. 

> [!TIP]
> If you want to use this now, feel free to go to my fork at https://github.com/piotrnajda3000/iconic/tree/folder-notes-integration, build the project, and copy main.js, manifest and styles.css into `.obsidian/plugins/iconic`. 

<img width="734" height="63" alt="image" src="https://github.com/user-attachments/assets/2c5177eb-f0f4-4806-b918-e0823c5752a2" />

## Example 

Rulebook:

<img width="490" height="245" alt="image" src="https://github.com/user-attachments/assets/bde8fc83-aaad-4584-918a-3a11d4a19958" />

With setting on for a Folder Note:

<img width="225" height="37" alt="image" src="https://github.com/user-attachments/assets/17f1e434-d906-4578-a038-ef84a5b2dd57" />

With setting off:

<img width="165" height="35" alt="image" src="https://github.com/user-attachments/assets/2ffa8148-37bb-447a-a917-bbc14f3bb613" />


## Changes Made (AI Generated)

1. IconicPlugin.ts - Added a new setting integrateFolderNotes (boolean, default false) to the IconicSettings interface and DEFAULT_SETTINGS.

2. Strings.ts - Added UI strings for the new setting:
•  integrateFolderNotes.name: "Folder Notes integration"
•  integrateFolderNotes.desc: "Apply file rules to folders when the matched file is that folder's Folder Note."

3. IconicSettingTab.ts - Added a toggle control in the "Sidebars & tabs" section to enable/disable the Folder Notes integration.

4. FileIconManager.ts - Implemented the core integration logic:
•  Added a folderNoteCache Map to cache folder → folder-note path mappings
•  Added clearFolderNoteCache() method to reset the cache
•  Added getFolderNotePath() helper method that:
•  Checks for detached folder notes first using Folder Notes plugin's excludeFolders settings
•  Computes attached folder note paths based on Folder Notes' folderNoteName, storageLocation, and folderNoteType settings
•  Falls back to supportedFileTypes if primary type not found
•  Modified refreshIcons() to clear the cache on each refresh
•  Modified refreshChildIcons() to:
•  For folders: check for a folder-note file ruling if no folder rule exists and integration is enabled
•  Apply the color-only folder-note rules by showing a colored default folder icon
•  Proper precedence: Folder rule > Folder-note rule > Manual folder icon
